### PR TITLE
Add code.google.com and *.googlecode.com to allowed hosts.

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -67,6 +67,7 @@ allow-hosts =
     *.4teamwork.ch
     effbot.org
     code.google.com
+    *.googlecode.com
 
 
 


### PR DESCRIPTION
These are both required to get "robotframework" which is a dependency of "ftw.testing". Without it "buildout -c test-plone-4.2.x.cfg" fails for ftw.testing.
