### PR TITLE
Made zeo entry in supervisor configuration configurable.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -33,6 +33,7 @@ supervisor-httpok-timeout = 40
 supervisor-email = zope@localhost
 supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
 supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
+supervisor-zeo-entry = 10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} true
 
 plone-languages = en de fr
 
@@ -91,7 +92,7 @@ user = supervisor
 password = admin
 
 programs =
-    10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} true
+    ${buildout:supervisor-zeo-entry}
     90 instance0 (startsecs=${buildout:supervisor-client-startsecs} autostart=false) ${buildout:bin-directory}/instance0 [console] true zope
     20 instance1 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance1 [console] true zope
 


### PR DESCRIPTION
In some installations, for example when using relstorage, there is no zeo in use. So it would be nice to deactivate the zeo entry in the supervisor configuration, devoid of copying the complete supervisor configuration.

@jone could you take a look?
