### PR TITLE
Introduce buildout:zcml-additional-fragments buildout variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,31 @@ An example:
         mywebsite
 
 
+.. _Additional ZCML:
+
+Additional ZCML
+~~~~~~~~~~~~~~~
+
+There is a `problem <https://github.com/plone/plone.recipe.zope2instance/pull/13>`_ with
+extending the ``zcml-additional``.
+As a workaround we use the ``buildout:zcml-additional-fragments`` variable, which takes
+care that ``zcml-additional`` is wrapped properly.
+
+Usage example:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.github.com/4teamwork/ftw-buildouts/master/production.cfg
+
+    deployment-number = 05
+
+    zcml-additional-fragments +=
+        <include package="my.package" file="meta.zcml" />
+        <myPackageSecurity token="123123" />
+
+
 Port range configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -199,6 +224,10 @@ Here is a full example, below is the detail explenation:
 
     plone-languages = en de fr
 
+    zcml-additional-fragments +=
+        <include package="my.package" file="meta.zcml" />
+        <myPackageSecurity token="123123" />
+
 
 These are the most common configuration settings.
 You can also override any options in the sections of the parts.
@@ -219,6 +248,7 @@ Details:
 - ``supervisor-httpok-options`` - Allows to change or extend the httpok settings per instance. The process name
   and the http address are added per ZEO client.
 - ``plone-languages`` - The short names of the languages which are loaded by Zope.
+- ``zcml-additional-fragments`` - Define additional zcml to load. See the `Additional ZCML`_ section.
 
 
 Tika server
@@ -239,7 +269,6 @@ Example:
         https://raw.github.com/4teamwork/ftw-buildouts/master/tika-server.cfg
 
     deployment-number = 05
-
 
 .. _coverage: http://pypi.python.org/pypi/coverage
 .. _Cobertura Jenkins Plugin: https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin

--- a/plone-development-tika.cfg
+++ b/plone-development-tika.cfg
@@ -4,9 +4,11 @@ parts +=
     tika-server
 
 
+zcml-additional-fragments += ${tika:zcml}
+
+
 [instance]
 eggs += ftw.tika
-zcml-additional += ${tika:zcml}
 
 
 [tika]

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -23,6 +23,8 @@ i18n-domain = ${buildout:package-namespace}
 
 always-checkout = false
 
+zcml-additional-fragments =
+
 
 [instance]
 recipe = plone.recipe.zope2instance
@@ -39,6 +41,10 @@ eggs =
 
 environment-vars =
     zope_i18n_compile_mo_files true
+zcml-additional =
+    <configure xmlns="http://namespaces.zope.org/zope">
+        ${buildout:zcml-additional-fragments}
+    </configure>
 
 
 [omelette]

--- a/production.cfg
+++ b/production.cfg
@@ -36,6 +36,8 @@ supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildo
 
 plone-languages = en de fr
 
+zcml-additional-fragments =
+
 
 
 
@@ -68,6 +70,11 @@ http-address = 1${buildout:deployment-number}00
 eggs =
     Plone
     ${buildout:instance-eggs}
+zcml-additional =
+    <configure xmlns="http://namespaces.zope.org/zope">
+        ${buildout:zcml-additional-fragments}
+    </configure>
+
 
 zope-conf-additional = datetime-format international
 environment-vars =

--- a/tika-server.cfg
+++ b/tika-server.cfg
@@ -5,9 +5,7 @@ parts +=
 
 instance-eggs += ftw.tika
 
-
-[instance0]
-zcml-additional += ${tika:zcml}
+zcml-additional-fragments += ${tika:zcml}
 
 
 [tika]


### PR DESCRIPTION
This PR introduces a `buildout:zcml-additional-fragments` buildout variable that can be used to effectively extend the resulting `zcml-additional` with `+=` assignments.

This is motivated by ZCML needed for `ftw.tika`:
[`tika-server.cfg`](https://github.com/4teamwork/ftw-buildouts/blob/master/tika-server.cfg#L10) currently includes

``` ini
[instance0]
zcml-additional += ${tika:zcml}
```

While it's a nice idea that `tika-server.cfg` is completely self-configuring, I don't think this can work reliably:
- `instance0:zcml-additional` often gets overridden in buildouts that extend from the `ftw-buildouts`.
- Because everything in `zcml-additional` needs to be wrapped in a single `<configure />` element, appending to it from multiple places using `+=` doesn't work.

Therefore I suggest to remove that `zcml-additional += ${tika:zcml}` and instead document in `README.rst` how to add tika's ZCML to `instance0:zcml-additional` in the buildout that extends from `tika-server.cfg`. That way its left to the developer to make sure the ZCML is included properly in whatever other additional ZCML he has in his buildout.

This issue really should be fixed in `plone.recipe.zope2instance` I guess - always wrap the contents of `zcml-additional` in an outer `<configure />` element if it contains more than one element.

As a work-around, we do this in some of our buildouts:
- Define `buildout:zcml-additional-fragments`
- Append to `buildout:zcml-additional-fragments` from multiple places using `+=`
- Wrap its contents in a  `<configure />` node and set `zcml-additional` to that:

``` ini
    [instance0]
    zcml-additional =
        <configure xmlns="http://namespaces.zope.org/zope">
            ${buildout:zcml-additional-fragments}
        </configure>
```

Maybe this pattern could also be useful in `ftw-buildouts`.
@jone any thoughts on this?
