### PR TITLE
Fix URL for Tika download and add MD5 hash.

### DIFF
--- a/tika-server.cfg
+++ b/tika-server.cfg
@@ -19,7 +19,8 @@ zcml =
 
 [tika-download]
 recipe = hexagonit.recipe.download
-url = http://mirror.switch.ch/mirror/apache/dist/tika/tika-app-1.4.jar
+url = https://archive.apache.org/dist/tika/tika-app-1.4.jar
+md5sum = 53936b30a84a933389ea959a36dd963e
 download-only = true
 filename = tika.jar
 


### PR DESCRIPTION
The download URL for tika 1.4 recently broke:
http://mirror.switch.ch/mirror/apache/dist/tika/tika-app-1.4.jar does not exist any more.
Because Switch removes old version quite aggressively, we replace the Tika download URL
with one pointing to https://archive.apache.org/dist/tika/ which should be much more stable.

Also verified that the MD5 sum of the archive from the new URL is the same as the old one
we used, and added that hash to the buildout.
/cc @phgross 
