### PR TITLE
Make operating system user configurable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,6 +223,8 @@ Here is a full example, below is the detail explenation:
     supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
     supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
 
+    os-user = zope
+
     plone-languages = en de fr
 
     zcml-additional-fragments +=
@@ -248,6 +250,9 @@ Details:
 - ``supervisor-memmon-options`` - Allows to change or extend the memmon configuration options.
 - ``supervisor-httpok-options`` - Allows to change or extend the httpok settings per instance. The process name
   and the http address are added per ZEO client.
+- ``os-user`` - The operating system user is used by supervisor, which makes sure
+  that the processes managed by supervisor are started with this user.
+  It defaults to ``zope``.
 - ``plone-languages`` - The short names of the languages which are loaded by Zope.
 - ``zcml-additional-fragments`` - Define additional zcml to load. See the `Additional ZCML`_ section.
 

--- a/maintenance-server.cfg
+++ b/maintenance-server.cfg
@@ -11,4 +11,4 @@ arguments = '${buildout:directory}/maintenance', 1${buildout:deployment-number}1
 
 [supervisor]
 programs +=
-    90 maintenance (autostart=false) ${buildout:bin-directory}/maintenance true zope
+    90 maintenance (autostart=false) ${buildout:bin-directory}/maintenance true ${buildout:os-user}

--- a/production.cfg
+++ b/production.cfg
@@ -30,9 +30,11 @@ instance-eggs =
 supervisor-client-startsecs = 60
 supervisor-memmon-size = 1200MB
 supervisor-httpok-timeout = 40
-supervisor-email = zope@localhost
+supervisor-email = ${buildout:os-user}@localhost
 supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
 supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
+
+os-user = zope
 
 plone-languages = en de fr
 
@@ -99,8 +101,8 @@ password = admin
 
 programs =
     10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} true
-    90 instance0 (startsecs=${buildout:supervisor-client-startsecs} autostart=false) ${buildout:bin-directory}/instance0 [console] true zope
-    20 instance1 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance1 [console] true zope
+    90 instance0 (startsecs=${buildout:supervisor-client-startsecs} autostart=false) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
+    20 instance1 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
 
 eventlisteners =
     Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
@@ -111,7 +113,7 @@ eventlisteners =
 
 [deployment]
 recipe = ftw.recipe.deployment
-logrotate-directory = /home/zope/etc/logrotate.d
+logrotate-directory = /home/${buildout:os-user}/etc/logrotate.d
 logrotate-options =
     rotate 4
     weekly

--- a/tika-server.cfg
+++ b/tika-server.cfg
@@ -33,4 +33,4 @@ arguments = -jar ${tika-download:destination}/${tika-download:filename} --server
 
 [supervisor]
 programs +=
-    10 tika-server (stopasgroup=true) ${buildout:bin-directory}/tika-server true zope
+    10 tika-server (stopasgroup=true) ${buildout:bin-directory}/tika-server true ${buildout:os-user}

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -10,7 +10,7 @@ http-address = 1${buildout:deployment-number}02
 
 [supervisor]
 programs +=
-    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true zope
+    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
 
 eventlisteners +=
     HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/]

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -16,8 +16,8 @@ http-address = 1${buildout:deployment-number}03
 
 [supervisor]
 programs +=
-    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true zope
-    20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true zope
+    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
 
 eventlisteners +=
     HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/]

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -22,9 +22,9 @@ http-address = 1${buildout:deployment-number}04
 
 [supervisor]
 programs +=
-    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true zope
-    20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true zope
-    20 instance4 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance4 [console] true zope
+    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
+    20 instance4 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
 
 eventlisteners +=
     HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/]


### PR DESCRIPTION
The new ${buildout:os-user} (defaults to "zope") makes it possible to change the operating system user used by supervisor to start processes.

This is especially helpful when locally testing deployment buildouts.
