### PR TITLE
Disable coverage on jenkins by default.

### DIFF
--- a/test-package.cfg
+++ b/test-package.cfg
@@ -22,6 +22,9 @@ prefer-final = false
 recipe = collective.recipe.template
 pre-test =
 post-test =
+test-command-coverage = bin/test-coverage xml $@
+test-command-no-coverage = bin/test $@
+test-command = ${test-jenkins:test-command-no-coverage}
 input = inline:
     #!/bin/sh
     mkdir -p ${buildout:results-dir}
@@ -45,7 +48,7 @@ input = inline:
     echo "</pre>" >> ${buildout:results-dir}/dependencies.html
 
     ${test-jenkins:pre-test}
-    bin/test-coverage xml $@
+    ${test-jenkins:test-command}
     result=$?
     ${test-jenkins:post-test}
     exit $result


### PR DESCRIPTION
Always generating a coverage report for all packages takes a lot of time
and I believe that most reports are never viewed.

This changes the default to run without coverage.
It can be re-enabled per package in the test buildout with:

``` ini
   [test-jenkins]
   test-command = ${test-jenkins:test-command-coverage}
```

@maethu 
