### PR TITLE
Fix race-condition when creating test_directory in test-base.cfg.

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -89,7 +89,10 @@ initialization =
     import os
     sys.argv[0] = os.path.abspath(sys.argv[0])
     test_directory = '${buildout:directory}/parts/test'
-    if not os.path.exists(test_directory): os.makedirs(test_directory)
+    try:
+        os.makedirs(test_directory)
+    except OSError:
+        pass
     os.chdir(test_directory)
     os.environ['zope_i18n_compile_mo_files'] = 'true'
 scripts = test


### PR DESCRIPTION
When running tests in parallel with `bin/mtest`, the line

```
 if not os.path.exists(test_directory): os.makedirs(test_directory)
```

causes a race condition if the directory has already been created by another worker. Using `try...except` instead avoids this race condition.

@deiferni

/cc @jone
