### PR TITLE
Prevent indentation error in bin/test

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -89,10 +89,8 @@ initialization =
     import os
     sys.argv[0] = os.path.abspath(sys.argv[0])
     test_directory = '${buildout:directory}/parts/test'
-    try:
-        os.makedirs(test_directory)
-    except OSError:
-        pass
+    try: os.makedirs(test_directory)
+    except OSError: pass
     os.chdir(test_directory)
     os.environ['zope_i18n_compile_mo_files'] = 'true'
 scripts = test


### PR DESCRIPTION
Whitespace apparently gets stripped completely when building `bin/test` from template.

@deiferni 
