### PR TITLE
Update Tika buildouts for JAXRS server (ftw.tika 2.x) 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ For example if we use ``deployment-number = 05`` the ports would be:
   "...", "bin/instance...", "..."
   10520, "bin/zeo", "ZEO Server (Database)"
   10530, "bin/solr-instance", "Solr instance"
-  10531, "bin/tika-server", "Tika Server"
+  10532, "bin/tika-server", "Tika JAXRS Server"
   10150, "bin/haproxy", "Haproxy (reserved, not installation yet)"
   10199, "bin/supervisord", "Supervisor daemon"
 
@@ -269,8 +269,9 @@ Example:
 Tika server
 ~~~~~~~~~~~
 
-The ``tika-server.cfg`` installs and configures `ftw.tika`_ as daemon, which provides
-document to text transforms (e.g. for fulltext indexing) using `Apache Tika`_.
+The ``tika-jaxrs-server.cfg`` installs and configures `ftw.tika`_, and sets up
+an `Apache Tika`_ JAXRS server as daemon, which provides document to text
+transforms (e.g. for fulltext indexing).
 A ``bin/tika-server`` script is installed and hooked up with supervisor and ``ftw.tika``
 is configured. You just need to install ``ftw.tika`` in ``portal_setup``.
 
@@ -281,7 +282,7 @@ Example:
     [buildout]
     extends =
         https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
-        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/tika-server.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/tika-jaxrs-server.cfg
 
     deployment-number = 05
 

--- a/plone-development-tika.cfg
+++ b/plone-development-tika.cfg
@@ -1,6 +1,7 @@
 [buildout]
 parts +=
-    tika-download
+    tika-app-download
+    tika-server-download
     tika-server
 
 
@@ -12,22 +13,31 @@ eggs += ftw.tika
 
 
 [tika]
-server-port = 8031
+server-port = 9998
 zcml =
     <configure xmlns:tika="http://namespaces.plone.org/tika">
-        <tika:config path="${tika-download:destination}/${tika-download:filename}"
+        <tika:config path="${tika-app-download:destination}/${tika-app-download:filename}"
                      port="${tika:server-port}" />
     </configure>
 
 
-[tika-download]
+[tika-app-download]
 recipe = hexagonit.recipe.download
-url = https://archive.apache.org/dist/tika/tika-app-1.5.jar
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
+md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
-filename = tika.jar
+filename = tika-app.jar
+
+
+[tika-server-download]
+recipe = hexagonit.recipe.download
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
+md5sum = 0f70548f233ead7c299bf7bc73bfec26
+download-only = true
+filename = tika-server.jar
 
 
 [tika-server]
 recipe = collective.recipe.scriptgen
 cmd = java
-arguments = -jar ${tika-download:destination}/${tika-download:filename} --server --port ${tika:server-port} --text
+arguments = -jar ${tika-server-download:destination}/${tika-server-download:filename} --port ${tika:server-port}

--- a/tika-jaxrs-server.cfg
+++ b/tika-jaxrs-server.cfg
@@ -10,7 +10,7 @@ zcml-additional-fragments += ${tika:zcml}
 
 
 [tika]
-server-port = 1${buildout:deployment-number}31
+server-port = 1${buildout:deployment-number}32
 zcml =
     <configure xmlns:tika="http://namespaces.plone.org/tika">
         <tika:config path="${tika-app-download:destination}/${tika-app-download:filename}"


### PR DESCRIPTION
This PR adds a new `tika-jaxrs-server.cfg` to download and configure the new [Tika JAX-RS](http://wiki.apache.org/tika/TikaJAXRS) server, which is required by `ftw.tika` 2.x.

It also updates  `plone-development-tika.cfg` for the new server.

The existing `tika-server.cfg` is still present, and will continue to work with `ftw.tika` 1.x.

@maethu @jone 
