### PR TITLE
Pin down zc.buildout and setuptools versions in order to fix test setups

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -9,7 +9,12 @@
 selenium =
 
 
-# Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
-zc.buildout=
-setuptools=
+# Pin down zc.buildout and setuptools:
+# zc.buildout==2.3 requires setuptools>=8.0, which causes version
+# specifiers to behave differently, and makes the 2.0.5 constraint for
+# five.localsitemanager fail the >2.0dev requirement of five.grok
+
+zc.buildout= <2.3
+setuptools= <8.0
+
 distribute=


### PR DESCRIPTION
Pin down zc.buildout and setuptools versions in order to fix bogus "bad constraint" errors caused by `setuptools==8.0`.

---

**Background**:

The recently released `zc.buildout==2.3` now requires `setuptools==8.0`. This `setuptools` version [includes changes](https://pypi.python.org/pypi/setuptools#id4) to the version parsing logic according to [PEP 440](http://legacy.python.org/dev/peps/pep-0440/).

Some of these changes cause (at least) one combination of a constraint (version pin) and requirement (from `setup.py`) from the Plone KGS to fail. This combination is the
- constraint for `five.localsitemanager` to `2.0.5` from the [Plone KGS](http://dist.plone.org/release/4.3-latest/versions.cfg) and the
- requirement `five.localsitemanager > 2.0dev` from [`five.grok`'s `setup.py`](https://github.com/zopefoundation/five.grok/blob/master/setup.py#L44).

With the new setuptools version, the immediate version comparison `parse_version('2.0.5') > parse_version('2.0dev')` still yields `True`, but comparing whether version `2.0.5` is in the specification `>2.0dev` fails:
- `'2.0.5' in Specification('>2.0dev')` -> `False`.

/cc @jone @maethu @phgross @deiferni 
