### PR TITLE
add bin/upgrade to plone-development.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,8 @@ Features:
   ``${buildout:package-name}-manual.pot`` (manually created translations) and
   ``${buildout:package-name}-content.pot`` (translations from `ftw.inflator`_
   initial content).
+- bin/upgrade: `ftw.upgrade <https://github.com/4teamwork/ftw.upgrade>`_ script
+  for managing upgrade steps.
 
 Example usage: add a configuration file to your
 package (``development.cfg``)::

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -17,6 +17,7 @@ parts +=
     instance
     zopepy
     i18n-build
+    upgrade
     omelette
 
 i18n-domain = ${buildout:package-namespace}
@@ -70,3 +71,8 @@ recipe = ftw.recipe.translations:package
 package-name = ${buildout:package-name}
 i18n-domain = ${buildout:i18n-domain}
 package-namespace = ${buildout:package-namespace}
+
+
+[upgrade]
+recipe = zc.recipe.egg:script
+eggs = ftw.upgrade


### PR DESCRIPTION
Adds a `bin/upgrade` script when `plone-development.cfg` is used.
// @lukasgraf 