### PR TITLE
Latest keyring releases 5.0, 5.1, 5.2 and 5.2.1 are not compatible, sinc...

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -362,6 +362,9 @@ zope.security = 3.8.3
 cssselect = 0.9
 
 
+# Latest keyring releases 5.0, 5.1, 5.2 and 5.2.1 are not compatible, since they require a specific setuptools version.
+keyring = 4.1.1
+
 # pylint > 0.25.2 is not distribute compatible. It does only register the
 # console_scripts entry points when setuptools is there - but we usually use
 # distribute now.


### PR DESCRIPTION
...e they require a specific setuptools version.

@jone 