### PR TITLE
production.cfg: Fix typo in allow-picked-versions option to make it actually work

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -12,7 +12,7 @@ parts =
 
 
 newest = false
-allowed-picked-versions = false
+allow-picked-versions = false
 show-picked-versions = true
 versions = versions
 


### PR DESCRIPTION
In `production.cfg` there's a [typo in the spelling of the `allow-picked-versions` option](https://github.com/4teamwork/ftw-buildouts/blob/fb1e8d53f4082ec2f4016c8a8ce503df26c5fe2d/production.cfg#L15). Because of that, this option never really had any effect, and chances are that several production buildouts will need to have their versions pinned once this is fixed.

/cc @4teamwork/coders 
Just mentioning you all to let you know about this change. If your production buildout fails in the next couple days with this message, this is why, so make sure you pin all of your versions:

```
While:
  Installing instance0.
  Getting distribution for 'some-package'.
Error: Picked: some-package = 1.2.3
```