### PR TITLE
Keep history for 7 days.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -57,7 +57,7 @@ parts = ${buildout:filestorage-parts}
 [zeo]
 recipe = plone.recipe.zeoserver
 zeo-address = 127.0.0.1:1${buildout:deployment-number}20
-
+pack-days = 7
 
 
 [instance0]


### PR DESCRIPTION
So it's easy to restore accidentally deleted content with zc.beforstorage.

@buchi @fguyer @jone 