### PR TITLE
Revert "Pin down zc.buildout and setuptools versions in order to fix"

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -17,12 +17,7 @@ splinter = 0.6.0
 collective.MockMailHost = 0.8
 
 
-# Pin down zc.buildout and setuptools:
-# zc.buildout==2.3 requires setuptools>=8.0, which causes version
-# specifiers to behave differently, and makes the 2.0.5 constraint for
-# five.localsitemanager fail the >2.0dev requirement of five.grok
-
-zc.buildout= <2.3
-setuptools= <8.0
-
+# Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
+zc.buildout=
+setuptools=
 distribute=


### PR DESCRIPTION
The temporarily down pinning of zc.buildout and setuptools is longer be necessary.

This reverts commit cbc3a2961eefcf08f4a9eaefcaf57842bf6ce03b.


@lukasgraf @jone 