### PR TITLE
Pin down `collective.recipe.template` for Plone 3.3x and 4.0.x tests.

### DIFF
--- a/test-plone-3.3.x.cfg
+++ b/test-plone-3.3.x.cfg
@@ -101,3 +101,6 @@ pep8 = 1.2
 
 # python2.4 compatible coverage
 coverage = 3.5.3
+
+# compatibility with zc.buildout 1.4
+collective.recipe.template = 1.11

--- a/test-plone-4.0.x.cfg
+++ b/test-plone-4.0.x.cfg
@@ -25,3 +25,6 @@ plone.app.testing = 4.2.2
 # geopy >= 1 is no longer python 2.6 compatible
 # (osm.py uses {}-set-syntax)
 geopy = <1
+
+# compatibility with zc.buildout 1.4
+collective.recipe.template = 1.11


### PR DESCRIPTION
Because the newest version (`1.12`) of `collective.recipe.template`, in particular this [PR](https://github.com/collective/collective.recipe.template/pull/6), breaks compatibility for `zc.buildout 1.4`.

@jone @lukasgraf as discussed ... 