### PR TITLE
Fix implicity dependency problem (CMFPlacefulWorkflow).

### DIFF
--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -15,6 +15,12 @@ eggs +=
     Products.PloneHotfix20121106
     Pillow
 
+# plone.app.testing now imports from Products.CMFPlacefulWorkflow, which
+# is often not installed because no explicity dependency is declared.
+# We now always install the Plone egg in order to have the full Plone stack ready.
+# https://github.com/plone/plone.app.upgrade/commit/b6a0f6e8865e94b53ff9f7f68385774fa7d5ab02
+    Plone
+
 
 [versions]
 # With Plone 4.1 we need collective.js.jqueryui < 1.9

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -12,6 +12,12 @@ eggs +=
     Products.PloneHotfix20130618
     Pillow
 
+# plone.app.testing now imports from Products.CMFPlacefulWorkflow, which
+# is often not installed because no explicity dependency is declared.
+# We now always install the Plone egg in order to have the full Plone stack ready.
+# https://github.com/plone/plone.app.upgrade/commit/b6a0f6e8865e94b53ff9f7f68385774fa7d5ab02
+    Plone
+
 
 [versions]
 # collective.js.jqueryui 1.9.1.0 is broken.


### PR DESCRIPTION
plone.app.testing now imports from Products.CMFPlacefulWorkflow, which
is often not installed because no explicity dependency is declared.
We now always install the Plone egg in order to have the full Plone stack ready.

The problem has been already fixed for the 4.3.x test setup, but 4.1.x and 4.2.x needs the fix as well.

@jone 