### PR TITLE
Add plone4.csrffixes.

### DIFF
--- a/hotfixes/4.1.3.cfg
+++ b/hotfixes/4.1.3.cfg
@@ -5,6 +5,7 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
     Products.Zope_Hotfix_20111024
 
 [versions]
@@ -13,3 +14,4 @@ Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.Zope_Hotfix_20111024 = 1.0
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.1.4.cfg
+++ b/hotfixes/4.1.4.cfg
@@ -5,6 +5,7 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.1.5.cfg
+++ b/hotfixes/4.1.5.cfg
@@ -5,6 +5,7 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.1.6.cfg
+++ b/hotfixes/4.1.6.cfg
@@ -5,6 +5,7 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.1.cfg
+++ b/hotfixes/4.2.1.cfg
@@ -5,6 +5,7 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.2.cfg
+++ b/hotfixes/4.2.2.cfg
@@ -5,6 +5,7 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.3.cfg
+++ b/hotfixes/4.2.3.cfg
@@ -4,9 +4,11 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.4.cfg
+++ b/hotfixes/4.2.4.cfg
@@ -4,9 +4,11 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.5.cfg
+++ b/hotfixes/4.2.5.cfg
@@ -4,9 +4,11 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.6.cfg
+++ b/hotfixes/4.2.6.cfg
@@ -3,8 +3,10 @@
 instance-eggs +=
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.cfg
+++ b/hotfixes/4.2.cfg
@@ -5,6 +5,7 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.1.cfg
+++ b/hotfixes/4.3.1.cfg
@@ -4,9 +4,11 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.2.cfg
+++ b/hotfixes/4.3.2.cfg
@@ -3,8 +3,10 @@
 instance-eggs +=
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.3.cfg
+++ b/hotfixes/4.3.3.cfg
@@ -2,7 +2,9 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.4.cfg
+++ b/hotfixes/4.3.4.cfg
@@ -2,7 +2,9 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.5.cfg
+++ b/hotfixes/4.3.5.cfg
@@ -2,7 +2,9 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.6.cfg
+++ b/hotfixes/4.3.6.cfg
@@ -2,7 +2,9 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.7.cfg
+++ b/hotfixes/4.3.7.cfg
@@ -1,6 +1,8 @@
 [buildout]
 
 instance-eggs +=
+    plone4.csrffixes
 
 
 [versions]
+plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.cfg
+++ b/hotfixes/4.3.cfg
@@ -4,9 +4,11 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
+    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
+plone4.csrffixes = 1.0.2


### PR DESCRIPTION
Add plone4.csrffixes.

- https://plone.org/products/plone/security/advisories/20151006-preannouncement
- https://plone.org/products/plone-hotfix/releases/20151006
- https://pypi.python.org/pypi/plone4.csrffixes

Affected Versions:
- Plone < 4 (1.x, 2.x, 3.x): affected but patch does not apply
- Plone 4.x: affected and patch applies to all currently released versions
- Plone 5.x: not affected, patch is not necessary.