### PR TITLE
Revert "Add plone4.csrffixes."

### DIFF
--- a/hotfixes/4.1.3.cfg
+++ b/hotfixes/4.1.3.cfg
@@ -5,7 +5,6 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
     Products.Zope_Hotfix_20111024
 
 [versions]
@@ -14,4 +13,3 @@ Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.Zope_Hotfix_20111024 = 1.0
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.1.4.cfg
+++ b/hotfixes/4.1.4.cfg
@@ -5,7 +5,6 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
@@ -13,4 +12,3 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.1.5.cfg
+++ b/hotfixes/4.1.5.cfg
@@ -5,7 +5,6 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
@@ -13,4 +12,3 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.1.6.cfg
+++ b/hotfixes/4.1.6.cfg
@@ -5,7 +5,6 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
@@ -13,4 +12,3 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.1.cfg
+++ b/hotfixes/4.2.1.cfg
@@ -5,7 +5,6 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
@@ -13,4 +12,3 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.2.cfg
+++ b/hotfixes/4.2.2.cfg
@@ -5,7 +5,6 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
@@ -13,4 +12,3 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.3.cfg
+++ b/hotfixes/4.2.3.cfg
@@ -4,11 +4,9 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.4.cfg
+++ b/hotfixes/4.2.4.cfg
@@ -4,11 +4,9 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.5.cfg
+++ b/hotfixes/4.2.5.cfg
@@ -4,11 +4,9 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.6.cfg
+++ b/hotfixes/4.2.6.cfg
@@ -3,10 +3,8 @@
 instance-eggs +=
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.2.cfg
+++ b/hotfixes/4.2.cfg
@@ -5,7 +5,6 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
@@ -13,4 +12,3 @@ Products.PloneHotfix20121106 = 1.2
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.1.cfg
+++ b/hotfixes/4.3.1.cfg
@@ -4,11 +4,9 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.2.cfg
+++ b/hotfixes/4.3.2.cfg
@@ -3,10 +3,8 @@
 instance-eggs +=
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.3.cfg
+++ b/hotfixes/4.3.3.cfg
@@ -2,9 +2,7 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.4.cfg
+++ b/hotfixes/4.3.4.cfg
@@ -2,9 +2,7 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.5.cfg
+++ b/hotfixes/4.3.5.cfg
@@ -2,9 +2,7 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.6.cfg
+++ b/hotfixes/4.3.6.cfg
@@ -2,9 +2,7 @@
 
 instance-eggs +=
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.7.cfg
+++ b/hotfixes/4.3.7.cfg
@@ -1,8 +1,6 @@
 [buildout]
 
 instance-eggs +=
-    plone4.csrffixes
 
 
 [versions]
-plone4.csrffixes = 1.0.2

--- a/hotfixes/4.3.cfg
+++ b/hotfixes/4.3.cfg
@@ -4,11 +4,9 @@ instance-eggs +=
     Products.PloneHotfix20130618
     Products.PloneHotfix20131210
     Products.PloneHotfix20150910
-    plone4.csrffixes
 
 
 [versions]
 Products.PloneHotfix20130618 = 1.3.1
 Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
-plone4.csrffixes = 1.0.2


### PR DESCRIPTION
Reverts 4teamwork/ftw-buildouts#30

As discussed internally, we do not want `plone4.csrffixes` to be automatically installed.
The reason is that this is not a security hole but a security feature: it enables auto-csrf.
This security feature needs to be integrated carefully in each application / site because it usually has side effects.
The side effects are usually that code triggers a "you may be hacked" confirmation page for the user because the code was not developed with auto-csrf, resulting in a confused user.

Another reason is that those changes actually result in broken buildouts, since the extended Plone KGSes have lower pinnings for `plone.protect`, `plone.keyring` and `plone.locking` than the constraints in `plone4.csrffixes`, resulting in that buildouts are no longer working which used to work before the PR #30 was merged.

We therefore do not list `plone.4csrffixes` in the ftw-buildouts hotfixes but encurage project owners to add those changes to their project buildouts.

/cc @buchi @lukasgraf 

