### PR TITLE
remove blessed pinning.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -16,11 +16,6 @@ splinter = 0.6.0
 # https://github.com/collective/collective.mockmailhost/pull/4
 collective.MockMailHost = 0.8
 
-# The ftw.upgrade dependency "blessed" latest release 1.10.0 is not compatible with plone 4.3.x
-# blessed requires six >= 1.9.0, plone pins 1.8.0.
-blessed = 1.9.5
-
-
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
 zc.buildout=
 setuptools=


### PR DESCRIPTION
As of ftw.upgrade = 1.15.0, blessed is no longer required.
We therefore no longer need to "fix" the pinning.

https://github.com/4teamwork/ftw.upgrade/pull/89