### PR TITLE
Implement solr configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ This repositories provides some base buildouts to extend for.
 
 It contains buildouts for testing and development as well as for production.
 
+.. contents:: Table of Contents
+
 
 Testing and development
 -----------------------
@@ -289,6 +291,91 @@ Example:
     deployment-number = 05
 
 
+Solr
+~~~~
+
+The solr configurations provide a standard way to install solr,
+based on `collective.solr`_ and `ftw.solr`_.
+
+Standard installation
++++++++++++++++++++++
+
+For production:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/solr.cfg
+
+    deployment-number = 05
+
+For local development:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development-solr.cfg
+
+
+Custom core configuration
++++++++++++++++++++++++++
+
+It is possible to change the solr core configuration or add additional cores.
+Take a look at the ``solr-core-template`` section in the ``solr-base.cfg``
+for the options you may change.
+
+For having the changes both, in production and development, the standard way to
+do customizations is to add a ``solr.cfg`` in your project repository and extend
+it both in development and in production buildout configurations.
+The ``solr.cfg`` is a configuration extension and should not extend anything.
+
+Example local ``solr.cfg``:
+
+.. code:: ini
+
+    [solr-settings]
+    solr-cores =
+        main-core
+        another-core
+    solr-default-core = main-core
+
+    [main-core]
+    <= solr-core-template
+    max-num-results = 2000
+
+    [anothre-core]
+    <= solr-core-template
+    max-num-results = 500
+
+
+Example ``production-*.cfg``:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/solr.cfg
+        solr.cfg
+
+    deployment-number = 05
+
+Example ``development.cfg``:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development-solr.cfg
+        solr.cfg
+
+
+
 Warmup
 ~~~~~~
 
@@ -378,3 +465,5 @@ will be included in the generated warmup configuration file.
 .. _ftw.maintenanceserver: https://github.com/4teamwork/ftw.maintenanceserver
 .. _Apache Tika: http://tika.apache.org/
 .. _collective.warmup: https://github.com/collective/collective.warmup
+.. _ftw.solr: https://github.com/4teamwork/ftw.solr
+.. _collective.solr: https://github.com/collective/collective.solr

--- a/plone-development-solr.cfg
+++ b/plone-development-solr.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/solr-base.cfg
+
+zcml-additional-fragments += ${solr-settings:zcml}
+
+
+[solr-settings]
+port = 8983

--- a/solr-base.cfg
+++ b/solr-base.cfg
@@ -1,0 +1,211 @@
+# Do not extend from this configuration directly.
+# Extend one of:
+# - solr.cfg
+# - plone-development-solr.cfg
+
+[buildout]
+parts +=
+    solr-download
+    solr-instance
+
+
+[solr-settings]
+# port =
+host = 127.0.0.1
+base = /solr
+solr-major-version = 4
+solr-dist-version = 4.10.4
+solr-dist-md5sum = 8ae107a760b3fc1ec7358a303886ca06
+solr-cores = solr-default-plone-core
+solr-default-core = solr-default-plone-core
+
+# Do not move this to buildout:zcml-additional-fragments in this file
+# because buildout is buggy when using += and nested extends.
+zcml =
+    <configure xmlns:solr="http://namespaces.plone.org/solr">
+        <solr:connection host="${solr-settings:host}"
+                         port="${solr-settings:port}"
+                         base="${solr-settings:base}"/>
+    </configure>
+
+
+
+[solr-download]
+recipe = hexagonit.recipe.download
+url = https://archive.apache.org/dist/lucene/solr/${solr-settings:solr-dist-version}/solr-${solr-settings:solr-dist-version}.tgz
+md5sum = ${solr-settings:solr-dist-md5sum}
+strip-top-level-dir = true
+
+
+[solr-instance]
+recipe = collective.recipe.solrinstance:mc
+solr-location = ${solr-download:location}
+host = ${solr-settings:host}
+port = ${solr-settings:port}
+basepath = ${solr-settings:base}
+solr-version = ${solr-settings:solr-major-version}
+
+java_opts =
+  -server
+  -Xms256M
+  -Xmx1024M
+
+cores = ${solr-settings:solr-cores}
+default-core-name = ${solr-settings:solr-default-core}
+
+
+[solr-default-plone-core]
+<= solr-core-template
+
+
+[solr-core-template]
+max-num-results = 1000
+section-name = SOLR
+unique-key = UID
+logdir = ${buildout:directory}/var/solr
+default-search-field = SearchableText
+unique-key = UID
+spellcheckField = SearchableText
+default-operator = AND
+updateLog = true
+requestParsers-enableRemoteStreaming = true
+solrconfig-shards =
+
+extra-field-types =
+    <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+          <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+          <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+          <filter class="solr.WordDelimiterFilterFactory"
+                  splitOnCaseChange="1"
+                  splitOnNumerics="1"
+                  stemEnglishPossessive="1"
+                  generateWordParts="1"
+                  generateNumberParts="1"
+                  catenateWords="1"
+                  catenateNumbers="1"
+                  catenateAll="0"
+                  preserveOriginal="0"/>
+          <filter class="solr.LowerCaseFilterFactory"/>
+          <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
+                  maxPosAsterisk="2" maxPosQuestion="1" minTrailing="2" maxFractionAsterisk="0"/>
+      </analyzer>
+      <analyzer type="query">
+          <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+          <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+          <filter class="solr.WordDelimiterFilterFactory"
+                  splitOnCaseChange="1"
+                  splitOnNumerics="1"
+                  stemEnglishPossessive="1"
+                  generateWordParts="1"
+                  generateNumberParts="1"
+                  catenateWords="0"
+                  catenateNumbers="0"
+                  catenateAll="0"
+                  preserveOriginal="0"/>
+          <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    <fieldType name="text_snippets" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+          <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+          <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+          <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+          <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    <!-- Field type for spell checking -->
+    <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+additional-solrconfig =
+    <!-- Request handler for search results with highlighting aka snippets -->
+    <requestHandler name="/hlsearch" class="solr.SearchHandler">
+        <lst name="defaults">
+            <str name="echoParams">explicit</str>
+            <int name="rows">10</int>
+            <!-- spellchecker -->
+            <str name="spellcheck.dictionary">default</str>
+            <str name="spellcheck">on</str>
+            <str name="spellcheck.extendedResults">true</str>
+            <str name="spellcheck.count">10</str>
+            <str name="spellcheck.alternativeTermCount">5</str>
+            <str name="spellcheck.maxResultsForSuggest">5</str>
+            <str name="spellcheck.collate">true</str>
+            <str name="spellcheck.collateExtendedResults">true</str>
+            <str name="spellcheck.maxCollationTries">10</str>
+            <str name="spellcheck.maxCollations">5</str>
+            <!-- snippets (aka highlighting) -->
+            <bool name="hl">true</bool>
+            <bool name="hl.useFastVectorHighlighter">true</bool>
+            <str name="hl.fl">snippetText</str>
+            <int name="hl.fragsize">200</int>
+            <str name="hl.alternateField">snippetText</str>
+            <int name="hl.maxAlternateFieldLength">200</int>
+            <int name="hl.snippets">3</int>
+            <!-- facet queries -->
+            <str name="facet.query">modified:[NOW/DAY TO *]</str>
+            <str name="facet.query">modified:[NOW/DAY-1DAY TO NOW/DAY]</str>
+            <str name="facet.query">modified:[NOW/DAY-7DAYS TO *]</str>
+            <str name="facet.query">modified:[NOW/DAY-1MONTH TO *]</str>
+            <str name="facet.query">modified:[NOW/DAY-1YEAR TO *]</str>
+            <str name="facet.query">modified:[* TO NOW/DAY-1YEAR]</str>
+            <!-- distributed searching: include external sites -->
+            ${:solrconfig-shards}
+        </lst>
+        <lst name="invariants">
+            <str name="fl">Creator Title Description modified portal_type path_string getIcon UID getRemoteUrl</str>
+        </lst>
+        <arr name="last-components">
+            <str>spellcheck</str>
+        </arr>
+    </requestHandler>
+    <!-- Request handler for Live Search.
+         Limit the returned fields to a minimum for maximum speed.-->
+    <requestHandler name="/livesearch" class="solr.SearchHandler">
+        <lst name="defaults">
+            <str name="echoParams">explicit</str>
+            <int name="rows">1000</int>
+        </lst>
+        <lst name="invariants">
+            <str name="fl">Title Description portal_type path_string getIcon getRemoteUrl Type</str>
+        </lst>
+    </requestHandler>
+
+index =
+    name:allowedRolesAndUsers   type:string stored:true multivalued:true
+    name:created                type:date stored:true
+    name:Creator                type:string stored:true
+    name:Date                   type:date stored:true
+    name:Description            type:text stored:true
+    name:effective              type:date stored:true
+    name:exclude_from_nav       type:boolean indexed:false stored:true
+    name:expires                type:date stored:true
+    name:getIcon                type:string indexed:false stored:true
+    name:getId                  type:string indexed:false stored:true
+    name:getRemoteUrl           type:string indexed:false stored:true
+    name:is_folderish           type:boolean stored:true
+    name:Language               type:string stored:true
+    name:modified               type:date stored:true
+    name:object_provides        type:string stored:true multivalued:true
+    name:path_depth             type:integer indexed:true stored:true
+    name:path_parents           type:string indexed:true stored:true multivalued:true
+    name:path_string            type:string indexed:false stored:true
+    name:portal_type            type:string stored:true
+    name:review_state           type:string stored:true
+    name:SearchableText         type:text_de stored:true
+    name:searchwords            type:string stored:true multivalued:true
+    name:showinsearch           type:boolean stored:true
+    name:site_area              type:string stored:true
+    name:snippetText            type:text_snippets stored:true termVectors:true termPositions:true termOffsets:true
+    name:Subject                type:string stored:true multivalued:true
+    name:Title                  type:text stored:true
+    name:Type                   type:string stored:true
+    name:UID                    type:string stored:true required:true

--- a/solr.cfg
+++ b/solr.cfg
@@ -1,0 +1,13 @@
+[buildout]
+extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/solr-base.cfg
+
+zcml-additional-fragments += ${solr-settings:zcml}
+
+
+[solr-settings]
+port = 1${buildout:deployment-number}30
+
+
+[supervisor]
+programs +=
+    15 solr (startsecs=5) ${buildout:bin-directory}/solr-instance [fg] true ${buildout:os-user}


### PR DESCRIPTION
Adds solr buildouts with a default configuration, mostly based on the configuration we use for Bern.

- `plone-development-solr.cfg` is used in development
- `solr.cfg` is used in production
- `solr-base.cfg` is not used directly but extended by the other two and contains shard configuration

I aim was to build a solution where I could use the same (custom) configuration for development and production without duplicating it.
When having custom configuration, for example more cores, the way to go is to add a `solr.cfg` to the project, which does not extend anything but is extended in addition to the buildouts above and acts as a mixin, changing the configuration.

The idea of these configurations is to provide the buildout, not to do anything with the Plone instance. Therefore the egg is not added. The user of the buildout may add `collective.solr` and / or `ftw.solr` to the his `setup.py`.

@buchi @lukasgraf @maethu please take a look as I have no idea what I'm doing :wink: 