### PR TITLE
Fix "hexagonit.recipe.download" automatic version picking.

### DIFF
--- a/tika-jaxrs-server.cfg
+++ b/tika-jaxrs-server.cfg
@@ -11,9 +11,11 @@ zcml-additional-fragments += ${tika:zcml}
 
 [tika]
 server-port = 1${buildout:deployment-number}32
+filename-app = tika-app.jar
+filename-server = tika-server.jar
 zcml =
     <configure xmlns:tika="http://namespaces.plone.org/tika">
-        <tika:config path="${tika-app-download:destination}/${tika-app-download:filename}"
+        <tika:config path="${buildout:parts-directory}/tika-app-download/${tika:filename-app}"
                      port="${tika:server-port}" />
     </configure>
 
@@ -24,7 +26,7 @@ recipe = hexagonit.recipe.download
 url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
 md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
-filename = tika-app.jar
+filename = ${tika:filename-app}
 
 
 [tika-server-download]
@@ -33,13 +35,13 @@ recipe = hexagonit.recipe.download
 url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
 md5sum = 0f70548f233ead7c299bf7bc73bfec26
 download-only = true
-filename = tika-server.jar
+filename = ${tika:filename-server}
 
 
 [tika-server]
 recipe = collective.recipe.scriptgen
 cmd = java
-arguments = -jar ${tika-server-download:destination}/${tika-server-download:filename} --port ${tika:server-port}
+arguments = -jar ${tika-server-download:destination}/${tika:filename-server} --port ${tika:server-port}
 
 
 [supervisor]


### PR DESCRIPTION
During buildout the version of "hexagonit.recipe.download" was reported of being picked automatically.

This happened because variables defined in a section which used the recipe "hexagonit.recipe.download" were used in other sections.