### PR TITLE
Configure packall, startup and shutdown scripts.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -115,6 +115,9 @@ eventlisteners =
 [deployment]
 recipe = ftw.recipe.deployment
 logrotate-directory = /home/${buildout:os-user}/etc/logrotate.d
+packall-symlink-directory = /home/${buildout:os-user}/etc/zodbpack.d
+startup-directory = /home/${buildout:os-user}/etc/startup.d
+shutdown-directory = /home/${buildout:os-user}/etc/shutdown.d
 logrotate-options =
     rotate 4
     weekly


### PR DESCRIPTION
Extend ftw.recipe.deployment configuration so that packall, startup and shutdown scripts are automatically generated and placed in the respective directory.

- Packall: https://github.com/4teamwork/ftw.recipe.deployment/pull/2
- Startup / shutdown: https://github.com/4teamwork/ftw.recipe.deployment/pull/3