### PR TITLE
Temporarily pin down setuptools to fix Jenkins builds

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -12,5 +12,8 @@ splinter = 0.6.0
 
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
 zc.buildout=
-setuptools=
+
+# Temporarily pin down setuptools to avoid issue with requirements parsing
+setuptools = <20.2
+
 distribute=


### PR DESCRIPTION
`setuptools-20.2` introduces a change in parsing of requirement versions, which breaks most of our builds.

Example failure:

```
An internal error occurred due to a bug in either zc.buildout or in a recipe being used:
Traceback (most recent call last):
  [...]
  File "setuptools-20.2-py2.7.egg/pkg_resources/_vendor/packaging/requirements.py", line 94, in __init__
    requirement_string[e.loc:e.loc + 8]))
InvalidRequirement: Invalid requirement, parse error at "'r22380'"
```

(When trying to parse a requirement like `plone.app.contentmenu >= 1.1.6dev-r22380`)

 `setuptools-20.2` has since been [pulled from PyPi](https://pypi.python.org/pypi/setuptools), so we should be able to remove this pin again once builds are back to green.

Also see: [setuptools issue #499 - version 20.2 doesn't like non numeric requirements](https://bitbucket.org/pypa/setuptools/issues/499/version-202-doesnt-like-non-numeric)

@jone