### PR TITLE
Introduce supervisor-httpok-view option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ Buildout configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
 There is a variety of options which can be configured in the buildout.
-Here is a full example, below is the detail explenation:
+Here is a full example, below is the detail explanation:
 
 .. code:: ini
 
@@ -214,6 +214,7 @@ Here is a full example, below is the detail explenation:
     supervisor-email = zope@localhost
     supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
     supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
+    supervisor-httpok-view =
 
     os-user = zope
 
@@ -242,6 +243,9 @@ Details:
 - ``supervisor-memmon-options`` - Allows to change or extend the memmon configuration options.
 - ``supervisor-httpok-options`` - Allows to change or extend the httpok settings per instance. The process name
   and the http address are added per ZEO client.
+- ``supervisor-httpok-view`` - Allows to specify a view name (or any path relative to the Zope application root)
+  that will be appended to the base URL for the instance, in order to build the full health check URL for the
+  HttpOk plugin. Must return 200 OK to indicate the instance is healthy.
 - ``os-user`` - The operating system user is used by supervisor, which makes sure
   that the processes managed by supervisor are started with this user.
   It defaults to ``zope``.

--- a/README.rst
+++ b/README.rst
@@ -209,10 +209,10 @@ Here is a full example, below is the detail explanation:
         mywebsite
 
     supervisor-client-startsecs = 60
-    supervisor-memmon-size = 1200MB
-    supervisor-httpok-timeout = 40
     supervisor-email = zope@localhost
+    supervisor-memmon-size = 1200MB
     supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
+    supervisor-httpok-timeout = 40
     supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
     supervisor-httpok-view =
 
@@ -236,11 +236,11 @@ Details:
 - ``supervisor-client-startsecs`` - The time in seconds it takes to start the ZEO client until Plone is ready
   to handle requests. This depends on your server and how big your database is. If it is too low, HttpOk will
   loop-restart the zeo clients when you restart all zeo clients at the same time and the server has load.
+- ``supervisor-email`` - The email address to notification messages of httpok and memmon are sent.
 - ``supervisor-memmon-size`` - The size of RAM each ZEO client can use. If it uses more, memmon will restart it.
+- ``supervisor-memmon-options`` - Allows to change or extend the memmon configuration options.
 - ``supervisor-httpok-timeout`` - The number of seconds that httpok should wait for a response to the
   HTTP request before timing out.
-- ``supervisor-email`` - The email address to notification messages of httpok and memmon are sent.
-- ``supervisor-memmon-options`` - Allows to change or extend the memmon configuration options.
 - ``supervisor-httpok-options`` - Allows to change or extend the httpok settings per instance. The process name
   and the http address are added per ZEO client.
 - ``supervisor-httpok-view`` - Allows to specify a view name (or any path relative to the Zope application root)

--- a/production.cfg
+++ b/production.cfg
@@ -33,10 +33,10 @@ filestorage-parts =
 instance-eggs =
 
 supervisor-client-startsecs = 60
-supervisor-memmon-size = 1200MB
-supervisor-httpok-timeout = 40
 supervisor-email = ${buildout:os-user}@localhost
+supervisor-memmon-size = 1200MB
 supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
+supervisor-httpok-timeout = 40
 supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
 supervisor-httpok-view =
 

--- a/production.cfg
+++ b/production.cfg
@@ -38,6 +38,7 @@ supervisor-httpok-timeout = 40
 supervisor-email = ${buildout:os-user}@localhost
 supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
 supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
+supervisor-httpok-view =
 
 os-user = zope
 
@@ -111,7 +112,7 @@ programs =
 
 eventlisteners =
     Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
-    HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/]
+    HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]
 
 
 

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -13,4 +13,4 @@ programs +=
     20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/]
+    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -20,5 +20,5 @@ programs +=
     20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/]
-    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/]
+    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -27,6 +27,6 @@ programs +=
     20 instance4 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/]
-    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/]
-    HttpOk4 TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/]
+    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk4 TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -43,4 +43,4 @@ programs +=
     20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true zope
 
 eventlisteners +=
-    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/]
+    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -14,4 +14,4 @@ programs +=
     20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true zope
 
 eventlisteners +=
-    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/]
+    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]


### PR DESCRIPTION
Introduces a `supervisor-httpok-view` option in the `[buildout]` stanza.

This allows to optionally define a view name (or any path relative to the Zope application root) that will be appended to the instance's base URL in order to build the full URL that the `HttpOk` plugin will use for its health checks.

(Defaults to empty string, and therefore still produces the same URL as before).

This enables us to use a custom view for health checks (for example one that is accessible for `Anonymous` but still uses a DB connection in order to trigger certain errors).

I tested this for both cases (default without a custom view name, and using a custom name).

**Note**: I also updated the publisher's sender / receiver instances. If one wants to use this feature with those, obviously both instances need to contain the egg in question that supplies the custom health check view.

@buchi @jone @maethu @phgross 
