### PR TITLE
Remove plone.recipe.precompiler from production.cfg

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -10,7 +10,6 @@ parts =
     instance1
     supervisor
     deployment
-    precompile
     zopepy
     upgrade
 
@@ -130,13 +129,6 @@ logrotate-options =
     missingok
     notifempty
     nomail
-
-
-
-[precompile]
-recipe = plone.recipe.precompiler
-eggs = ${instance0:eggs}
-compile-mo-files = true
 
 
 


### PR DESCRIPTION
If the buildout directory is the same as a development egg (which is the case for policy packages checked out from source that include the buildout config alongside the code), it will scan pretty much the entire deployment directory during buildout.

For deployments with many files, such as a reasonably large blobstorage, this leads to a severe **performance hit** while running buildout.

Closes #41 

@jone @maethu 