### PR TITLE
🚧 Add Products.PloneHotfix20160830

### DIFF
--- a/hotfixes/4.0.1.cfg
+++ b/hotfixes/4.0.1.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -27,6 +28,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.10.cfg
+++ b/hotfixes/4.0.10.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20111024
@@ -19,6 +20,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.0.2.cfg
+++ b/hotfixes/4.0.2.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -27,6 +28,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.3.cfg
+++ b/hotfixes/4.0.3.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -27,6 +28,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.4.cfg
+++ b/hotfixes/4.0.4.cfg
@@ -9,6 +9,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -25,6 +26,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.5.cfg
+++ b/hotfixes/4.0.5.cfg
@@ -9,6 +9,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -25,6 +26,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.6.1.cfg
+++ b/hotfixes/4.0.6.1.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -23,6 +24,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.6.cfg
+++ b/hotfixes/4.0.6.cfg
@@ -9,6 +9,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -25,6 +26,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.7.cfg
+++ b/hotfixes/4.0.7.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -23,6 +24,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.0.8.cfg
+++ b/hotfixes/4.0.8.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20111024
@@ -22,6 +23,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.0.9.cfg
+++ b/hotfixes/4.0.9.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20111024
@@ -22,6 +23,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.0.cfg
+++ b/hotfixes/4.0.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20110622
@@ -27,6 +28,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0

--- a/hotfixes/4.1.1.cfg
+++ b/hotfixes/4.1.1.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20111024
@@ -19,6 +20,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.1.2.cfg
+++ b/hotfixes/4.1.2.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20111024
@@ -19,6 +20,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.1.3.cfg
+++ b/hotfixes/4.1.3.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20111024
@@ -19,6 +20,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.1.4.cfg
+++ b/hotfixes/4.1.4.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -18,6 +19,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.1.5.cfg
+++ b/hotfixes/4.1.5.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -18,6 +19,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.1.6.cfg
+++ b/hotfixes/4.1.6.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -18,6 +19,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.1.cfg
+++ b/hotfixes/4.1.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
     Products.Zope_Hotfix_20111024
@@ -22,6 +23,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.2.1.cfg
+++ b/hotfixes/4.2.1.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -18,6 +19,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.2.2.cfg
+++ b/hotfixes/4.2.2.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -18,6 +19,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.2.3.cfg
+++ b/hotfixes/4.2.3.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -16,6 +17,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.2.4.cfg
+++ b/hotfixes/4.2.4.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -16,6 +17,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.2.5.cfg
+++ b/hotfixes/4.2.5.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -16,6 +17,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.2.6.cfg
+++ b/hotfixes/4.2.6.cfg
@@ -5,6 +5,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -14,6 +15,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.2.7.cfg
+++ b/hotfixes/4.2.7.cfg
@@ -5,6 +5,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -14,6 +15,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.2.cfg
+++ b/hotfixes/4.2.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -18,6 +19,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.1.cfg
+++ b/hotfixes/4.3.1.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -16,6 +17,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.10.cfg
+++ b/hotfixes/4.3.10.cfg
@@ -1,11 +1,13 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.11.cfg
+++ b/hotfixes/4.3.11.cfg
@@ -1,11 +1,13 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.2.cfg
+++ b/hotfixes/4.3.2.cfg
@@ -5,6 +5,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -14,6 +15,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.3.cfg
+++ b/hotfixes/4.3.3.cfg
@@ -4,6 +4,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -12,6 +13,7 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.4.cfg
+++ b/hotfixes/4.3.4.cfg
@@ -4,6 +4,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -12,6 +13,7 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.5.cfg
+++ b/hotfixes/4.3.5.cfg
@@ -4,6 +4,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -12,6 +13,7 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.6.cfg
+++ b/hotfixes/4.3.6.cfg
@@ -4,6 +4,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -12,6 +13,7 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.7.cfg
+++ b/hotfixes/4.3.7.cfg
@@ -3,6 +3,7 @@
 hotfix-eggs =
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -10,6 +11,7 @@ hotfix-eggs =
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.8.cfg
+++ b/hotfixes/4.3.8.cfg
@@ -2,12 +2,14 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.9.cfg
+++ b/hotfixes/4.3.9.cfg
@@ -2,12 +2,14 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/4.3.cfg
+++ b/hotfixes/4.3.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -16,6 +17,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/5.0.2.cfg
+++ b/hotfixes/5.0.2.cfg
@@ -2,12 +2,14 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/5.0.3.cfg
+++ b/hotfixes/5.0.3.cfg
@@ -2,12 +2,14 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/5.0.4.cfg
+++ b/hotfixes/5.0.4.cfg
@@ -2,12 +2,14 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/5.0.5.cfg
+++ b/hotfixes/5.0.5.cfg
@@ -1,11 +1,13 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/5.0.6.cfg
+++ b/hotfixes/5.0.6.cfg
@@ -1,11 +1,13 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
 
 [versions]
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/5.0.cfg
+++ b/hotfixes/5.0.cfg
@@ -3,6 +3,7 @@
 hotfix-eggs =
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20160830
     Products.PloneHotfix20161129
     Products.PloneHotfix20170117
 
@@ -10,6 +11,7 @@ hotfix-eggs =
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20160830 = 1.3
 Products.PloneHotfix20161129 = 1.2
 Products.PloneHotfix20170117 = 1.0
 

--- a/hotfixes/update.py
+++ b/hotfixes/update.py
@@ -12,7 +12,6 @@ HOTFIX_VERSIONS = {}
 
 BLACKLIST = (
     'plone4.csrffixes',
-    'Products.PloneHotfix20160830',
 )
 
 STATIC_VERSIONS_TEXT = '''


### PR DESCRIPTION
Install `Products.PloneHotfix20160830` for all Plone versions.
We need to test if we have problems with the patch.

/CC @4teamwork/dev-plone  
