### PR TITLE
Buildouts for installing redis.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -385,7 +385,7 @@ Redis
 
 In the ``redis`` folder there are standard buildouts for installing a dedicated
 redis installation within the buildout directory.
-You can simple extend ``redis/development.cfg`` or ``redis/production.cfg``,
+You can simply extend ``redis/development.cfg`` or ``redis/production.cfg``,
 depending on your base config file, and then choose the redis version with
 e.g. ``redis/3.2.3.cfg``.
 

--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,7 @@ For example if we use ``deployment-number = 05`` the ports would be:
   10520, "bin/zeo", "ZEO Server (Database)"
   10530, "bin/solr-instance", "Solr instance"
   10532, "bin/tika-server", "Tika JAXRS Server"
+  10533, "bin/redis", "Redis instance"
   10150, "bin/haproxy", "Haproxy (reserved, not installation yet)"
   10199, "bin/supervisord", "Supervisor daemon"
 
@@ -378,6 +379,36 @@ Example ``development.cfg``:
         https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development-solr.cfg
         solr.cfg
 
+
+Redis
+~~~~~
+
+In the ``redis`` folder there are standard buildouts for installing a dedicated
+redis installation within the buildout directory.
+You can simple extend ``redis/development.cfg`` or ``redis/production.cfg``,
+depending on your base config file, and then choose the redis version with
+e.g. ``redis/3.2.3.cfg``.
+
+Production buildout example:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/3.2.3.cfg
+
+Local development buildout example:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        test-plone-4.3.7.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/3.2.3.cfg
 
 
 Warmup

--- a/redis/3.2.3.cfg
+++ b/redis/3.2.3.cfg
@@ -1,0 +1,3 @@
+[redis-settings]
+redis-version = 3.2.3
+redis-md5sum = 138209b54dfc9819e6aea7b9503f8bd3

--- a/redis/base.cfg
+++ b/redis/base.cfg
@@ -11,7 +11,7 @@ pidfile = ${buildout:directory}/var/redis.pid
 logfile = ${buildout:directory}/var/log/redis.log
 
 # appendonly enables AOF storage, which is not enabled in the default config.
-# see
+# see http://redis.io/topics/persistence
 appendonly = yes
 dbfilebase = redis
 dir = ${buildout:directory}/var

--- a/redis/base.cfg
+++ b/redis/base.cfg
@@ -1,0 +1,70 @@
+# Redis base configuration.
+# Use development.cfg or production.cfg, not base.cfg directly.
+
+[redis-settings]
+# port = # set by development.cfg or production.cfg
+# redis-version = # set by [version].cfg
+bind = 127.0.0.1
+timeout = 0
+configfile = ${buildout:parts-directory}/redis/redis.conf
+pidfile = ${buildout:directory}/var/redis.pid
+logfile = ${buildout:directory}/var/log/redis.log
+
+# appendonly enables AOF storage, which is not enabled in the default config.
+# see
+appendonly = yes
+dbfilebase = redis
+dir = ${buildout:directory}/var
+
+# We cannot add a [buildout] secion in this file because it is
+# an indirect, 3rd level extends and declaring a [buildout]
+# part will break / reset values. Thanks buildout.
+parts =
+    redis-download
+    redis-build
+    redis-server
+    redis-py
+
+
+[redis-download]
+recipe = hexagonit.recipe.download
+strip-top-level-dir = true
+url = http://download.redis.io/releases/redis-${redis-settings:redis-version}.tar.gz
+md5sum = ${redis-settings:redis-md5sum}
+destination = ${buildout:parts-directory}/redis-${redis-settings:redis-version}
+
+
+[redis-build]
+recipe = collective.recipe.cmd
+on_install = true
+on_update = false
+cmds = cd ${redis-download:location} && make
+
+
+[redis-server]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/sh
+    ${redis-download:location}/src/redis-server ${redis-server:args-default} ${redis-server:args-custom}
+args-default =
+    --port ${redis-settings:port} \
+    --bind ${redis-settings:bind} \
+    --timeout ${redis-settings:timeout} \
+    --pidfile ${redis-settings:pidfile} \
+    --logfile ${redis-settings:logfile} \
+    --dir ${redis-settings:dir} \
+    --dbfilename ${redis-settings:dbfilebase}.rdb \
+    --appendfilename ${redis-settings:dbfilebase}.aof
+    --appendonly ${redis-settings:appendonly}
+args-custom =
+output = ${buildout:directory}/bin/redis-server
+mode = 755
+
+
+[redis-py]
+recipe = zc.recipe.egg:scripts
+eggs = redis
+interpreter = redispy
+initialization =
+    import redis
+    r = redis.StrictRedis(host='localhost', port=${redis-settings:port}, db=0)

--- a/redis/base.cfg
+++ b/redis/base.cfg
@@ -6,15 +6,17 @@
 # redis-version = # set by [version].cfg
 bind = 127.0.0.1
 timeout = 0
-configfile = ${buildout:parts-directory}/redis/redis.conf
-pidfile = ${buildout:directory}/var/redis.pid
-logfile = ${buildout:directory}/var/log/redis.log
-
+filenamebase = redis
+dir = ${buildout:directory}/var/redis
+configfile = ${buildout:parts-directory}/redis/${redis-settings:filenamebase}.conf
+pidfile = ${redis-settings:dir}/${redis-settings:filenamebase}.pid
+sockfile = ${redis-settings:dir}/${redis-settings:filenamebase}.sock
+logfile = ${redis-settings:dir}/${redis-settings:filenamebase}.log
+rdb_filename = ${redis-settings:filenamebase}.rdb
+aof_filename = ${redis-settings:filenamebase}.aof
 # appendonly enables AOF storage, which is not enabled in the default config.
 # see http://redis.io/topics/persistence
 appendonly = yes
-dbfilebase = redis
-dir = ${buildout:directory}/var
 
 # We cannot add a [buildout] secion in this file because it is
 # an indirect, 3rd level extends and declaring a [buildout]
@@ -22,6 +24,7 @@ dir = ${buildout:directory}/var
 parts =
     redis-download
     redis-build
+    redis-ensure-var-exists
     redis-server
     redis-py
 
@@ -41,6 +44,13 @@ on_update = false
 cmds = cd ${redis-download:location} && make
 
 
+[redis-ensure-var-exists]
+recipe = collective.recipe.cmd
+on_install = true
+on_update = true
+cmds = mkdir -p ${redis-settings:dir}
+
+
 [redis-server]
 recipe = collective.recipe.template
 input = inline:
@@ -52,9 +62,10 @@ args-default =
     --timeout ${redis-settings:timeout} \
     --pidfile ${redis-settings:pidfile} \
     --logfile ${redis-settings:logfile} \
+    --unixsocket ${redis-settings:sockfile} \
     --dir ${redis-settings:dir} \
-    --dbfilename ${redis-settings:dbfilebase}.rdb \
-    --appendfilename ${redis-settings:dbfilebase}.aof
+    --dbfilename ${redis-settings:rdb_filename} \
+    --appendfilename ${redis-settings:aof_filename} \
     --appendonly ${redis-settings:appendonly}
 args-custom =
 output = ${buildout:directory}/bin/redis-server

--- a/redis/development.cfg
+++ b/redis/development.cfg
@@ -1,0 +1,12 @@
+# collective.taskqueue configuration, setting up a redis as persistent queue.
+# Requires:
+# - deveopment.cfg
+# - redis/[version].cfg
+
+[buildout]
+extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/base.cfg
+parts += ${redis-settings:parts}
+
+
+[redis-settings]
+port = 8984

--- a/redis/production.cfg
+++ b/redis/production.cfg
@@ -1,0 +1,17 @@
+# collective.taskqueue configuration, setting up a redis as persistent queue.
+# Requires:
+# - production.cfg
+# - redis/[version].cfg
+
+[buildout]
+extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/base.cfg
+parts += ${redis-settings:parts}
+
+
+[redis-settings]
+port = 1${buildout:deployment-number}33
+
+
+[supervisor]
+programs +=
+    16 redis (startsecs=2 stopasgroup=true) ${buildout:bin-directory}/redis-server true ${buildout:os-user}


### PR DESCRIPTION
Sometimes a Redis installation should be shipped along with the a project.
These buildouts help downloading, building and configuring a redis installation for production and for development purposes.

/cc @lukasgraf @maethu @buchi 