### PR TITLE
Add collective.taskqueue buildouts.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -416,6 +416,70 @@ Local development buildout example:
         https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/3.2.3.cfg
 
 
+collective.taskqueue
+~~~~~~~~~~~~~~~~~~~~
+
+When using `collective.taskqueue`_, you need to configure a queue and a
+queue-server in your buildout.
+For convenience there are some standard queue configuration buildouts which simply
+can be exended.
+
+Local volatile queue
+++++++++++++++++++++
+
+The local volatile queue is an in-memory queue which will be lost when terminating
+a process. If you do important stuff you should consider installing redis.
+
+For production:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/taskqueue/volatile-production.cfg
+
+For development:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        test-plone-4.3.x.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/taskqueue/volatile-development.cfg
+
+
+Redis queue
++++++++++++
+
+Redis can be used as queue backend.
+By default, redis is not configured to really persist everything.
+With the standard configuration provided in ``ftw-buildouts``, redis is set up
+and configured to persist the queue.
+
+For production:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/taskqueue/redis-production.cfg
+
+For development:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        test-plone-4.3.x.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/redis/development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/taskqueue/redis-development.cfg
+
+
 Warmup
 ~~~~~~
 
@@ -507,3 +571,4 @@ will be included in the generated warmup configuration file.
 .. _collective.warmup: https://github.com/collective/collective.warmup
 .. _ftw.solr: https://github.com/4teamwork/ftw.solr
 .. _collective.solr: https://github.com/collective/collective.solr
+.. _collective.taskqueue: https://github.com/collective/collective.taskqueue

--- a/taskqueue/redis-development.cfg
+++ b/taskqueue/redis-development.cfg
@@ -1,0 +1,20 @@
+# collective.taskqueue configuration, configuring a redis taks queue
+# for a development environment.
+# Requires:
+# - development.cfg
+# - redis/development.cfg
+
+
+[instance]
+# Load redis extras of collective.taskqueue:
+eggs += collective.taskqueue [redis]
+
+zope-conf-additional =
+    %import collective.taskqueue
+    <taskqueue>
+        type redis
+        unix_socket_path ${redis-settings:sockfile}
+    </taskqueue>
+    <taskqueue-server>
+      name ${:_buildout_section_name_}
+    </taskqueue-server>

--- a/taskqueue/redis-development.cfg
+++ b/taskqueue/redis-development.cfg
@@ -9,7 +9,7 @@
 # Load redis extras of collective.taskqueue:
 eggs += collective.taskqueue [redis]
 
-zope-conf-additional =
+zope-conf-additional +=
     %import collective.taskqueue
     <taskqueue>
         type redis

--- a/taskqueue/redis-development.cfg
+++ b/taskqueue/redis-development.cfg
@@ -1,4 +1,4 @@
-# collective.taskqueue configuration, configuring a redis taks queue
+# collective.taskqueue configuration, configuring a redis tasks queue
 # for a development environment.
 # Requires:
 # - development.cfg

--- a/taskqueue/redis-production.cfg
+++ b/taskqueue/redis-production.cfg
@@ -9,7 +9,7 @@
 # Load redis extras of collective.taskqueue:
 eggs += collective.taskqueue [redis]
 
-zope-conf-additional =
+zope-conf-additional +=
     %import collective.taskqueue
     <taskqueue>
         type redis

--- a/taskqueue/redis-production.cfg
+++ b/taskqueue/redis-production.cfg
@@ -1,0 +1,20 @@
+# collective.taskqueue configuration, configuring a redis taks queue
+# for a production environment.
+# Requires:
+# - production.cfg
+# - redis/production.cfg
+
+
+[instance0]
+# Load redis extras of collective.taskqueue:
+eggs += collective.taskqueue [redis]
+
+zope-conf-additional =
+    %import collective.taskqueue
+    <taskqueue>
+        type redis
+        unix_socket_path ${redis-settings:sockfile}
+    </taskqueue>
+    <taskqueue-server>
+      name ${:_buildout_section_name_}
+    </taskqueue-server>

--- a/taskqueue/redis-production.cfg
+++ b/taskqueue/redis-production.cfg
@@ -1,4 +1,4 @@
-# collective.taskqueue configuration, configuring a redis taks queue
+# collective.taskqueue configuration, configuring a redis tasks queue
 # for a production environment.
 # Requires:
 # - production.cfg

--- a/taskqueue/volatile-development.cfg
+++ b/taskqueue/volatile-development.cfg
@@ -1,0 +1,10 @@
+# collective.taskqueue configuration, configuring a volatile (non-persistent)
+# task queue for local development.
+# Requires:
+# - plone-development.cfg
+
+[instance]
+zope-conf-additional +=
+    %import collective.taskqueue
+    <taskqueue />
+    <taskqueue-server />

--- a/taskqueue/volatile-production.cfg
+++ b/taskqueue/volatile-production.cfg
@@ -1,0 +1,11 @@
+# collective.taskqueue configuration, configuring a volatile (non-persistent)
+# task queue for a production environment.
+# Requires:
+# - production.cfg
+
+
+[instance0]
+zope-conf-additional =
+    %import collective.taskqueue
+    <taskqueue />
+    <taskqueue-server />

--- a/taskqueue/volatile-production.cfg
+++ b/taskqueue/volatile-production.cfg
@@ -5,7 +5,7 @@
 
 
 [instance0]
-zope-conf-additional =
+zope-conf-additional +=
     %import collective.taskqueue
     <taskqueue />
     <taskqueue-server />


### PR DESCRIPTION
Provide standard taskqueue queue configurations for production and for development, including a local volatile queue and a redis queue configuration each.

Requires https://github.com/4teamwork/ftw-buildouts/pull/45 (Redis)

/cc @lukasgraf @maethu @buchi 