### PR TITLE
Revert "add autostart options for HttpOk and Memmon."

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,11 +214,9 @@ Here is a full example, below is the detail explanation:
     supervisor-email = zope@localhost
     supervisor-memmon-size = 1200MB
     supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
-    supervisor-memmon-autostart = true
     supervisor-httpok-timeout = 40
     supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
     supervisor-httpok-view =
-    supervisor-httpok-autostart = true
 
     os-user = zope
 
@@ -243,7 +241,6 @@ Details:
 - ``supervisor-email`` - The email address to notification messages of httpok and memmon are sent.
 - ``supervisor-memmon-size`` - The size of RAM each ZEO client can use. If it uses more, memmon will restart it.
 - ``supervisor-memmon-options`` - Allows to change or extend the memmon configuration options.
-- ``supervisor-memmon-autostart`` - Start memmon when starting the supervisor daemon. Default: ``true``.
 - ``supervisor-httpok-timeout`` - The number of seconds that httpok should wait for a response to the
   HTTP request before timing out.
 - ``supervisor-httpok-options`` - Allows to change or extend the httpok settings per instance. The process name
@@ -251,7 +248,6 @@ Details:
 - ``supervisor-httpok-view`` - Allows to specify a view name (or any path relative to the Zope application root)
   that will be appended to the base URL for the instance, in order to build the full health check URL for the
   HttpOk plugin. Must return 200 OK to indicate the instance is healthy.
-- ``supervisor-httpok-autostart`` - Start HttpOk when starting the supervisor daemon. Default: ``true``.
 - ``os-user`` - The operating system user is used by supervisor, which makes sure
   that the processes managed by supervisor are started with this user.
   It defaults to ``zope``.

--- a/production.cfg
+++ b/production.cfg
@@ -35,11 +35,9 @@ supervisor-client-startsecs = 60
 supervisor-email = ${buildout:os-user}@localhost
 supervisor-memmon-size = 1200MB
 supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
-supervisor-memmon-autostart = true
 supervisor-httpok-timeout = 40
 supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
 supervisor-httpok-view =
-supervisor-httpok-autostart = true
 
 os-user = zope
 
@@ -112,8 +110,8 @@ programs =
     20 instance1 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
 
 eventlisteners =
-    Memmon (autostart=${buildout:supervisor-memmon-autostart}) TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
-    HttpOk1 (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]
+    Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
+    HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]
 
 
 

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -13,4 +13,4 @@ programs +=
     20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOk2 (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -20,5 +20,5 @@ programs +=
     20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOk2 (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
-    HttpOk3 (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -27,6 +27,6 @@ programs +=
     20 instance4 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOk2 (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
-    HttpOk3 (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
-    HttpOk4 (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOk4 TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -43,4 +43,4 @@ programs +=
     20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOkpub (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -14,4 +14,4 @@ programs +=
     20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlisteners +=
-    HttpOkpub (autostart=${buildout:supervisor-httpok-autostart}) TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
+    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]


### PR DESCRIPTION
This reverts commit 8ae5f04bf804d61a7a2957432048fb2f3f1b412d.

The option definition is only available in a new plone.recipe.supervisor. As we have older versions in production we cannot use this syntax and must find another solution.

// @lukasgraf @phgross