### PR TITLE
extract supervisor eventlisteners into variables.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -109,9 +109,12 @@ programs =
     90 instance0 (startsecs=${buildout:supervisor-client-startsecs} autostart=false) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
     20 instance1 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
 
+eventlistener-memmon = Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
+eventlistener-httpok1 = HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]
+
 eventlisteners =
-    Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
-    HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]
+    ${supervisor:eventlistener-memmon}
+    ${supervisor:eventlistener-httpok1}
 
 
 

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -12,5 +12,6 @@ http-address = 1${buildout:deployment-number}02
 programs +=
     20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
 
+eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
-    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+    ${supervisor:eventlistener-httpok2}

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -19,6 +19,8 @@ programs +=
     20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
     20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
 
+eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
-    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
-    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
+    ${supervisor:eventlistener-httpok2}
+    ${supervisor:eventlistener-httpok3}

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -26,7 +26,10 @@ programs +=
     20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
     20 instance4 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
 
+eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
+eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
+eventlistener-httpok4 = HttpOk4 TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
-    HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
-    HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
-    HttpOk4 TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/${buildout:supervisor-httpok-view}]
+    ${supervisor:eventlistener-httpok2}
+    ${supervisor:eventlistener-httpok3}
+    ${supervisor:eventlistener-httpok4}

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -42,5 +42,6 @@ zope-conf-additional =
 programs +=
     20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
+eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
-    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
+    ${supervisor:eventlistener-httpokpub}

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -13,5 +13,6 @@ http-address = 1${buildout:deployment-number}10
 programs +=
     20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
+eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
-    HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
+    ${supervisor:eventlistener-httpokpub}


### PR DESCRIPTION
In #48 we had to revert the httpok / memmon autostart feature because we
might have older plone.recipe.supervisor versions which do not support
this syntax.

On order to be able to not have HttpOk (or Memmon) eventlisteners we
move the listener definition into separate buildout variables, one for
each listener, and then just join the variables.

This gives us the possibility to overwrite the "eventlisteners" option
and join only the variables of the wanted event listeners, skipping
those which we do not want.

This solves the initial use case: to not have HttpOk eventlisteners run
or configured.

// @lukasgraf @phgross @maethu 