### PR TITLE
supervisor-haproxy event listener configuration.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,8 +185,10 @@ For example if we use ``deployment-number = 05`` the ports would be:
   10530, "bin/solr-instance", "Solr instance"
   10532, "bin/tika-server", "Tika JAXRS Server"
   10533, "bin/redis", "Redis instance"
-  10150, "bin/haproxy", "Haproxy (reserved, not installation yet)"
-  10199, "bin/supervisord", "Supervisor daemon"
+  10550, "bin/haproxy", "Haproxy (reserved, not installation yet)"
+  10599, "bin/supervisord", "Supervisor daemon"
+  8800, "HaProxy", "HaProxy status page (Server-wide)"
+  8801, "HaProxy", "HaProxy stats socket (Server-wide)"
 
 
 Buildout configuration
@@ -254,6 +256,57 @@ Details:
 - ``plone-languages`` - The short names of the languages which are loaded by Zope.
 - ``zcml-additional-fragments`` - Define additional zcml to load. See the `Additional ZCML`_ section.
 
+
+HaProxy / Supervisor integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `supervisor-haproxy`_ event listener tells haproxy to remove backends / add
+backends to the load balancing when supervisor detects instances to be stopping
+and starting.
+
+Example configuration:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/zeoclients/3.c
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg
+
+    deployment-number = 05
+
+    # supervisor-haproxy-backend = plone${buildout:deployment-number}
+    # supervisor-haproxy-socket = tcp://localhost:8801
+
+
+The ``haproxy.cfg`` preconfigures the supervisor event listener when standardized
+names in HaProxy. If you do not follow our naming standards you may want to
+configure the event listener manually or by modifying the ``supervisor-haproxy-*``
+configurations in the ``[buildout]``-section.
+
+Example HaProxy configuration:
+
+.. code:: ini
+
+    global
+       stats socket ipv4@0.0.0.0:8801 level admin
+
+    defaults
+        mode http
+        timeout connect 10s
+        timeout client 5m
+        timeout server 5m
+
+
+    frontend plone04
+        bind *:10450
+        default_backend plone04
+
+    backend plone04
+        server plone0401 localhost:10401 cookie p01 check inter 10s downinter 15s maxconn 5 rise 1 slowstart 60s
+        server plone0402 localhost:10402 cookie p02 check inter 10s downinter 15s maxconn 5 rise 1 slowstart 60s
+        server plone0403 localhost:10403 cookie p03 check inter 10s downinter 15s maxconn 5 rise 1 slowstart 60s
 
 
 Maintenance HTTP Server
@@ -569,3 +622,4 @@ will be included in the generated warmup configuration file.
 .. _ftw.solr: https://github.com/4teamwork/ftw.solr
 .. _collective.solr: https://github.com/collective/collective.solr
 .. _collective.taskqueue: https://github.com/collective/collective.taskqueue
+.. _supervisor-haproxy: https://pypi.python.org/pypi/supervisor-haproxy

--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ Details:
 - ``zcml-additional-fragments`` - Define additional zcml to load. See the `Additional ZCML`_ section.
 
 
-HaProxy / Supervisor integration
+HAProxy / Supervisor integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `supervisor-haproxy`_ event listener tells haproxy to remove backends / add
@@ -271,7 +271,7 @@ Example configuration:
     [buildout]
     extends =
         https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
-        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/zeoclients/3.c
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/zeoclients/3.cfg
         https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/haproxy.cfg
 
     deployment-number = 05
@@ -280,10 +280,10 @@ Example configuration:
     # supervisor-haproxy-socket = tcp://localhost:8801
 
 
-The ``haproxy.cfg`` preconfigures the supervisor event listener when standardized
-names in HaProxy. If you do not follow our naming standards you may want to
-configure the event listener manually or by modifying the ``supervisor-haproxy-*``
-configurations in the ``[buildout]``-section.
+The ``haproxy.cfg`` works well when using names in HAProxy such as "plone05" for
+the backend and "plone0502" for the servers (=zope instances).
+If you name backends and servers differently you may want to configure the name
+with ``supervisor-haproxy-backend`` variable.
 
 Example HaProxy configuration:
 

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,0 +1,4 @@
+[supervisor]
+plugins += supervisor-haproxy
+eventlistener-haproxy = HaProxy PROCESS_STATE ${buildout:bin-directory}/supervisor-haproxy [${buildout:supervisor-haproxy-socket} ${buildout:supervisor-haproxy-programs}]
+eventlisteners += ${supervisor:eventlistener-haproxy}

--- a/production.cfg
+++ b/production.cfg
@@ -38,6 +38,9 @@ supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:
 supervisor-httpok-timeout = 40
 supervisor-httpok-options = -t ${buildout:supervisor-httpok-timeout} -m ${buildout:supervisor-email}
 supervisor-httpok-view =
+supervisor-haproxy-backend = plone${buildout:deployment-number}
+supervisor-haproxy-socket = tcp://localhost:8801
+supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}01
 
 os-user = zope
 

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -2,6 +2,8 @@
 parts +=
     instance2
 
+supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}01 instance2:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}02
+
 
 [instance2]
 <= instance0

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -3,6 +3,8 @@ parts +=
     instance2
     instance3
 
+supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}01 instance2:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}02 instance3:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}03
+
 
 [instance2]
 <= instance0

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -4,6 +4,8 @@ parts +=
     instance3
     instance4
 
+supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}01 instance2:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}02 instance3:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}03 instance4:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}04
+
 
 [instance2]
 <= instance0


### PR DESCRIPTION
The `supervisor-haproxy` event listener tells haproxy to remove backends / add backends to the load balancing when supervisor detects instances to be stopping and starting.

The `production.cfg` contains the default configuration variables such as the haproxy-socket or the program mapping variable but it does not set up the event listener. The zeoclients-config-files then extend the program configuration dynamically.

For actually enabling the feature the `haproxy.cfg` must be extended. This way we avoid accidental activation.