### PR TITLE
add chameleon.cfg for configuring Chameleon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -607,6 +607,38 @@ The ``warmup-configuration:urls`` and ``warmup-configuration:url-sections`` opti
 will be included in the generated warmup configuration file.
 
 
+Chameleon
+~~~~~~~~~
+
+The ``chameleon.cfg`` enables the Chameleon templating engine with our custom
+integration `ftw.chameleon`_ and provides default configuration for use in
+production and development.
+
+If you want to run your tests with chameleon, you should add ``ftw.chameleon``
+to the ``install_requires`` list in your ``setup.py``.
+
+Production example:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/chameleon.cfg
+
+    deployment-number = 05
+
+
+Development example:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/chameleon.cfg
+
+
 
 .. _coverage: http://pypi.python.org/pypi/coverage
 .. _Cobertura Jenkins Plugin: https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin
@@ -623,3 +655,4 @@ will be included in the generated warmup configuration file.
 .. _collective.solr: https://github.com/collective/collective.solr
 .. _collective.taskqueue: https://github.com/collective/collective.taskqueue
 .. _supervisor-haproxy: https://pypi.python.org/pypi/supervisor-haproxy
+.. _ftw.chameleon: https://github.com/4teamwork/ftw.chameleon

--- a/chameleon.cfg
+++ b/chameleon.cfg
@@ -1,0 +1,22 @@
+[buildout]
+instance-eggs += ftw.chameleon
+parts += chameleon-cache
+environment-vars +=
+    CHAMELEON_EAGER ${buildout:chameleon-eager}
+    CHAMELEON_RELOAD ${buildout:chameleon-reload}
+    CHAMELEON_CACHE ${buildout:chameleon-cache}
+    FTW_CHAMELEON_RECOOK_WARNING ${buildout:chameleon-recook-warning}
+    FTW_CHAMELEON_RECOOK_EXCEPTION ${buildout:chameleon-recook-exception}
+
+
+[chameleon-cache]
+recipe = collective.recipe.shelloutput
+commands =
+    cmd1 = mkdir -p ${buildout:chameleon-cache}
+
+
+[test]
+eggs += ftw.chameleon
+initialization +=
+    import os
+    if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = '${buildout:chameleon-cache}'

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -31,6 +31,12 @@ instance-eggs =
 environment-vars =
     zope_i18n_compile_mo_files true
 
+chameleon-eager = false
+chameleon-reload = true
+chameleon-cache = ${buildout:directory}/var/chameleon-cache
+chameleon-recook-warning = false
+chameleon-recook-exception = false
+
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -28,6 +28,8 @@ show-picked-versions = true
 
 zcml-additional-fragments =
 instance-eggs =
+environment-vars =
+    zope_i18n_compile_mo_files true
 
 
 [instance]
@@ -44,8 +46,7 @@ eggs =
     plone.reload
     collective.z3cinspector
 
-environment-vars =
-    zope_i18n_compile_mo_files true
+environment-vars = ${buildout:environment-vars}
 zcml-additional =
     <configure xmlns="http://namespaces.zope.org/zope">
         ${buildout:zcml-additional-fragments}

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -27,6 +27,7 @@ dump-picked-versions = true
 show-picked-versions = true
 
 zcml-additional-fragments =
+instance-eggs =
 
 
 [instance]
@@ -39,6 +40,7 @@ blob-storage = var/blobstorage
 eggs =
     Plone
     ${buildout:package-name}
+    ${buildout:instance-eggs}
     plone.reload
     collective.z3cinspector
 

--- a/production.cfg
+++ b/production.cfg
@@ -42,6 +42,13 @@ supervisor-haproxy-backend = plone${buildout:deployment-number}
 supervisor-haproxy-socket = tcp://localhost:8801
 supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}01
 
+chameleon-eager = true
+chameleon-reload = false
+chameleon-cache = ${buildout:directory}/var/chameleon-cache
+chameleon-recook-warning = true
+chameleon-recook-exception = false
+
+
 os-user = zope
 
 plone-languages = en de fr

--- a/production.cfg
+++ b/production.cfg
@@ -47,6 +47,10 @@ os-user = zope
 plone-languages = en de fr
 
 zcml-additional-fragments =
+environment-vars =
+    PTS_LANGUAGES ${buildout:plone-languages}
+    zope_i18n_allowed_languages ${buildout:plone-languages}
+    zope_i18n_compile_mo_files true
 
 
 
@@ -87,10 +91,7 @@ zcml-additional =
 
 
 zope-conf-additional = datetime-format international
-environment-vars =
-    PTS_LANGUAGES ${buildout:plone-languages}
-    zope_i18n_allowed_languages ${buildout:plone-languages}
-    zope_i18n_compile_mo_files true
+environment-vars = ${buildout:environment-vars}
 
 
 


### PR DESCRIPTION
The `chameleon.cfg` enables the Chameleon templating engine with our custom integration `ftw.chameleon` and provides default configuration for use in production and development.

In order to easily share the same buildout configs for production and development I did these changes:
- Let `plone-development.cfg` support the `buildout:instance-eggs` variable.
- Move `envornment-vars` option to the `buildout` section in production and development.