### PR TITLE
graceful shutdown of zope instances.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -32,6 +32,9 @@ filestorage-parts =
 instance-eggs =
 
 supervisor-client-startsecs = 60
+supervisor-client-stopsignal = HUP
+supervisor-client-stopwaitsecs = 30
+supervisor-client-process-opts = startsecs=${buildout:supervisor-client-startsecs} stopsignal=${buildout:supervisor-client-stopsignal} stopwaitsecs=${buildout:supervisor-client-stopwaitsecs}
 supervisor-email = ${buildout:os-user}@localhost
 supervisor-memmon-size = 1200MB
 supervisor-memmon-options = -a ${buildout:supervisor-memmon-size} -m ${buildout:supervisor-email}
@@ -117,8 +120,8 @@ password = admin
 
 programs =
     10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} true
-    90 instance0 (startsecs=${buildout:supervisor-client-startsecs} autostart=false) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
-    20 instance1 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
+    90 instance0 (${buildout:supervisor-client-process-opts} autostart=false) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
+    20 instance1 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
 
 eventlistener-memmon = Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
 eventlistener-httpok1 = HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -12,7 +12,7 @@ http-address = 1${buildout:deployment-number}02
 
 [supervisor]
 programs +=
-    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -18,8 +18,8 @@ http-address = 1${buildout:deployment-number}03
 
 [supervisor]
 programs +=
-    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
-    20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -24,9 +24,9 @@ http-address = 1${buildout:deployment-number}04
 
 [supervisor]
 programs +=
-    20 instance2 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
-    20 instance3 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
-    20 instance4 (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
+    20 instance4 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -40,7 +40,7 @@ zope-conf-additional =
 
 [supervisor]
 programs +=
-    20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
+    20 instancepub (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -11,7 +11,7 @@ http-address = 1${buildout:deployment-number}10
 
 [supervisor]
 programs +=
-    20 instancepub (startsecs=${buildout:supervisor-client-startsecs}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
+    20 instancepub (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=


### PR DESCRIPTION
Change supervisor configuration so that we send "SIGHUP" instead of "SIGINT" when stopping zope instances. The "SIGHUP" increases the graceful shutdown from 1 second to 30 seconds. We therefore also change the stopwaitsecs to 30s (was 10s by default).

When now doing "./bin/supervisorctl stop instance2", pending requests are still finished as long as they do not take longer than 30 seconds. 30 seconds is the maximum defined in "Lifetime".

// @maethu @lukasgraf @buchi 