### PR TITLE
Fix self-update by not setting "newest" option.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -14,8 +14,12 @@ parts =
     upgrade
 
 
-newest = false
+# Warning: newest=false has the effect that buildout does not self-update,
+# therefore we do not set it here. If you set allow-picked-versions to true
+# you should consider setting newest to false.
+# newest = false
 allow-picked-versions = false
+
 show-picked-versions = true
 versions = versions
 


### PR DESCRIPTION
The "newest=false" option has the effect that buildout does no longer self-update when another version is pinned than istalled.

This may be quite a problem especially when we rely on having at least a certain buildout version.

Since we use allow-picked-versions=false we can remove the "newest=false" option since this means all versions have to be pinned anyways.