### PR TITLE
Add Products.PloneHotfix20161129

### DIFF
--- a/hotfixes/4.0.1.cfg
+++ b/hotfixes/4.0.1.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -25,6 +26,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.10.cfg
+++ b/hotfixes/4.0.10.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20111024
 
 
@@ -17,4 +18,5 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.0.2.cfg
+++ b/hotfixes/4.0.2.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -25,6 +26,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.3.cfg
+++ b/hotfixes/4.0.3.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -25,6 +26,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.4.cfg
+++ b/hotfixes/4.0.4.cfg
@@ -9,6 +9,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -23,6 +24,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.5.cfg
+++ b/hotfixes/4.0.5.cfg
@@ -9,6 +9,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -23,6 +24,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.6.1.cfg
+++ b/hotfixes/4.0.6.1.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -21,6 +22,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.6.cfg
+++ b/hotfixes/4.0.6.cfg
@@ -9,6 +9,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -23,6 +24,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.7.cfg
+++ b/hotfixes/4.0.7.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -21,6 +22,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.8.cfg
+++ b/hotfixes/4.0.8.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
 
@@ -20,5 +21,6 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.9.cfg
+++ b/hotfixes/4.0.9.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
 
@@ -20,5 +21,6 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.0.cfg
+++ b/hotfixes/4.0.cfg
@@ -10,6 +10,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20110622
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
@@ -25,6 +26,7 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.1.1.cfg
+++ b/hotfixes/4.1.1.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20111024
 
 
@@ -17,4 +18,5 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.1.2.cfg
+++ b/hotfixes/4.1.2.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20111024
 
 
@@ -17,4 +18,5 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.1.3.cfg
+++ b/hotfixes/4.1.3.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20111024
 
 
@@ -17,4 +18,5 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20111024 = 1.0

--- a/hotfixes/4.1.4.cfg
+++ b/hotfixes/4.1.4.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -16,3 +17,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.1.5.cfg
+++ b/hotfixes/4.1.5.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -16,3 +17,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.1.6.cfg
+++ b/hotfixes/4.1.6.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -16,3 +17,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.1.cfg
+++ b/hotfixes/4.1.cfg
@@ -8,6 +8,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
     Products.Zope_Hotfix_20111024
     Products.Zope_Hotfix_CVE_2010_3198
 
@@ -20,5 +21,6 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0

--- a/hotfixes/4.2.1.cfg
+++ b/hotfixes/4.2.1.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -16,3 +17,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.2.2.cfg
+++ b/hotfixes/4.2.2.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -16,3 +17,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.2.3.cfg
+++ b/hotfixes/4.2.3.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -14,3 +15,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.2.4.cfg
+++ b/hotfixes/4.2.4.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -14,3 +15,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.2.5.cfg
+++ b/hotfixes/4.2.5.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -14,3 +15,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.2.6.cfg
+++ b/hotfixes/4.2.6.cfg
@@ -5,6 +5,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.2.7.cfg
+++ b/hotfixes/4.2.7.cfg
@@ -5,6 +5,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.2.cfg
+++ b/hotfixes/4.2.cfg
@@ -7,6 +7,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -16,3 +17,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.1.cfg
+++ b/hotfixes/4.3.1.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -14,3 +15,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.10.cfg
+++ b/hotfixes/4.3.10.cfg
@@ -1,6 +1,8 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20161129
 
 
 [versions]
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.11.cfg
+++ b/hotfixes/4.3.11.cfg
@@ -1,6 +1,8 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20161129
 
 
 [versions]
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.2.cfg
+++ b/hotfixes/4.3.2.cfg
@@ -5,6 +5,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -12,3 +13,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.3.cfg
+++ b/hotfixes/4.3.3.cfg
@@ -4,9 +4,11 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.4.cfg
+++ b/hotfixes/4.3.4.cfg
@@ -4,9 +4,11 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.5.cfg
+++ b/hotfixes/4.3.5.cfg
@@ -4,9 +4,11 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.6.cfg
+++ b/hotfixes/4.3.6.cfg
@@ -4,9 +4,11 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.7.cfg
+++ b/hotfixes/4.3.7.cfg
@@ -3,8 +3,10 @@
 hotfix-eggs =
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.8.cfg
+++ b/hotfixes/4.3.8.cfg
@@ -2,7 +2,9 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.9.cfg
+++ b/hotfixes/4.3.9.cfg
@@ -2,7 +2,9 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/4.3.cfg
+++ b/hotfixes/4.3.cfg
@@ -6,6 +6,7 @@ hotfix-eggs =
     Products.PloneHotfix20150910
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
@@ -14,3 +15,4 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/5.0.2.cfg
+++ b/hotfixes/5.0.2.cfg
@@ -2,7 +2,9 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/5.0.3.cfg
+++ b/hotfixes/5.0.3.cfg
@@ -2,7 +2,9 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/5.0.4.cfg
+++ b/hotfixes/5.0.4.cfg
@@ -2,7 +2,9 @@
 
 hotfix-eggs =
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/5.0.5.cfg
+++ b/hotfixes/5.0.5.cfg
@@ -1,6 +1,8 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20161129
 
 
 [versions]
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/5.0.6.cfg
+++ b/hotfixes/5.0.6.cfg
@@ -1,6 +1,8 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20161129
 
 
 [versions]
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/5.0.cfg
+++ b/hotfixes/5.0.cfg
@@ -3,8 +3,10 @@
 hotfix-eggs =
     Products.PloneHotfix20151208
     Products.PloneHotfix20160419
+    Products.PloneHotfix20161129
 
 
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+Products.PloneHotfix20161129 = 1.2

--- a/hotfixes/update.py
+++ b/hotfixes/update.py
@@ -69,7 +69,7 @@ def requirement_filter(plone_version):
     def required(hotfix):
         for first, last in hotfix.get('required_for_plone'):
             first = pkg_resources.parse_version(first)
-            last = pkg_resources.parse_version(last)
+            last = pkg_resources.parse_version(last.replace('.??', '.99'))
             if first <= plone_version <= last:
                 return True
 


### PR DESCRIPTION
Add the security patch Products.PloneHotfix20161129 to all sites and all Plone versions.

@buchi please merge whenever we want to make sure the patch is applied to all our sites.

//cc FYI @4teamwork/dev-plone 