### PR TITLE
Tests: pin setuptools in order to avoid version conflict.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -12,5 +12,8 @@ splinter = 0.6.0
 
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
 zc.buildout= >2
-setuptools=
 distribute=
+
+# setuptools 34.0.0 unbundles six and adds a version constraint which is
+# incompatible Plone KGS.
+setuptools = 33.1.1


### PR DESCRIPTION
Setuptools 34.0.0 unbundles and pins "six" to "six>=1.10.0".
As older Plone versions pin six to 1.4.1, we get version conflicts.

By pinning down setuptools we can avoid a lot of broken builds.

/cc @maethu 