### PR TITLE
supply pin for fake elementtree.

### DIFF
--- a/hotfixes/4.0.1.cfg
+++ b/hotfixes/4.0.1.cfg
@@ -28,3 +28,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.10.cfg
+++ b/hotfixes/4.0.10.cfg
@@ -18,3 +18,11 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.2.cfg
+++ b/hotfixes/4.0.2.cfg
@@ -28,3 +28,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.3.cfg
+++ b/hotfixes/4.0.3.cfg
@@ -28,3 +28,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.4.cfg
+++ b/hotfixes/4.0.4.cfg
@@ -26,3 +26,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.5.cfg
+++ b/hotfixes/4.0.5.cfg
@@ -26,3 +26,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.6.1.cfg
+++ b/hotfixes/4.0.6.1.cfg
@@ -24,3 +24,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.6.cfg
+++ b/hotfixes/4.0.6.cfg
@@ -26,3 +26,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.7.cfg
+++ b/hotfixes/4.0.7.cfg
@@ -24,3 +24,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.8.cfg
+++ b/hotfixes/4.0.8.cfg
@@ -22,3 +22,11 @@ Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.9.cfg
+++ b/hotfixes/4.0.9.cfg
@@ -22,3 +22,11 @@ Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.0.cfg
+++ b/hotfixes/4.0.cfg
@@ -28,3 +28,11 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.1.1.cfg
+++ b/hotfixes/4.1.1.cfg
@@ -18,3 +18,11 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.1.2.cfg
+++ b/hotfixes/4.1.2.cfg
@@ -18,3 +18,11 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.1.3.cfg
+++ b/hotfixes/4.1.3.cfg
@@ -18,3 +18,11 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.1.4.cfg
+++ b/hotfixes/4.1.4.cfg
@@ -16,3 +16,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.1.5.cfg
+++ b/hotfixes/4.1.5.cfg
@@ -16,3 +16,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.1.6.cfg
+++ b/hotfixes/4.1.6.cfg
@@ -16,3 +16,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.1.cfg
+++ b/hotfixes/4.1.cfg
@@ -22,3 +22,11 @@ Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.1.cfg
+++ b/hotfixes/4.2.1.cfg
@@ -16,3 +16,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.2.cfg
+++ b/hotfixes/4.2.2.cfg
@@ -16,3 +16,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.3.cfg
+++ b/hotfixes/4.2.3.cfg
@@ -14,3 +14,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.4.cfg
+++ b/hotfixes/4.2.4.cfg
@@ -14,3 +14,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.5.cfg
+++ b/hotfixes/4.2.5.cfg
@@ -14,3 +14,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.6.cfg
+++ b/hotfixes/4.2.6.cfg
@@ -12,3 +12,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.7.cfg
+++ b/hotfixes/4.2.7.cfg
@@ -12,3 +12,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.2.cfg
+++ b/hotfixes/4.2.cfg
@@ -16,3 +16,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.1.cfg
+++ b/hotfixes/4.3.1.cfg
@@ -14,3 +14,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.10.cfg
+++ b/hotfixes/4.3.10.cfg
@@ -4,3 +4,11 @@ hotfix-eggs =
 
 
 [versions]
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.11.cfg
+++ b/hotfixes/4.3.11.cfg
@@ -4,3 +4,11 @@ hotfix-eggs =
 
 
 [versions]
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.2.cfg
+++ b/hotfixes/4.3.2.cfg
@@ -12,3 +12,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.3.cfg
+++ b/hotfixes/4.3.3.cfg
@@ -10,3 +10,11 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.4.cfg
+++ b/hotfixes/4.3.4.cfg
@@ -10,3 +10,11 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.5.cfg
+++ b/hotfixes/4.3.5.cfg
@@ -10,3 +10,11 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.6.cfg
+++ b/hotfixes/4.3.6.cfg
@@ -10,3 +10,11 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.7.cfg
+++ b/hotfixes/4.3.7.cfg
@@ -8,3 +8,11 @@ hotfix-eggs =
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.8.cfg
+++ b/hotfixes/4.3.8.cfg
@@ -6,3 +6,11 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.9.cfg
+++ b/hotfixes/4.3.9.cfg
@@ -6,3 +6,11 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/4.3.cfg
+++ b/hotfixes/4.3.cfg
@@ -14,3 +14,11 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/5.0.2.cfg
+++ b/hotfixes/5.0.2.cfg
@@ -6,3 +6,11 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/5.0.3.cfg
+++ b/hotfixes/5.0.3.cfg
@@ -6,3 +6,11 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/5.0.4.cfg
+++ b/hotfixes/5.0.4.cfg
@@ -6,3 +6,11 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/5.0.5.cfg
+++ b/hotfixes/5.0.5.cfg
@@ -4,3 +4,11 @@ hotfix-eggs =
 
 
 [versions]
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/5.0.6.cfg
+++ b/hotfixes/5.0.6.cfg
@@ -4,3 +4,11 @@ hotfix-eggs =
 
 
 [versions]
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/5.0.cfg
+++ b/hotfixes/5.0.cfg
@@ -8,3 +8,11 @@ hotfix-eggs =
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow

--- a/hotfixes/update.py
+++ b/hotfixes/update.py
@@ -15,6 +15,16 @@ BLACKLIST = (
     'Products.PloneHotfix20160830',
 )
 
+STATIC_VERSIONS_TEXT = '''
+
+# ``elementtree`` is included in Python, therefore we do not
+# want to install it.
+# We supply a version pin for a fake / hollow elementtree egg.
+# - http://psc.4teamwork.ch/dist/elementtree
+# - https://github.com/4teamwork/hollow-elementtree
+elementtree = hollow
+'''
+
 
 def update_hotfixes_files():
     hotfixes = load_hotfixes()
@@ -39,6 +49,8 @@ def update_hotfixes_files():
             for package in map(itemgetter('package'), proposed):
                 hotfix_version = get_hotfix_version(package)
                 fileio.write('{} = {}\n'.format(package, hotfix_version))
+
+            fileio.write(STATIC_VERSIONS_TEXT)
 
 
 def load_hotfixes():


### PR DESCRIPTION
``elementtree`` is included in Python, therefore we do not want to install it.
We supply a version pin for a fake / hollow elementtree egg.
 - http://psc.4teamwork.ch/dist/elementtree
 - https://github.com/4teamwork/hollow-elementtree

This prevents us from having to track down each and every dependency that still has a requirement for `elementtree`, and at the same time ensures that the requirement is satisfied, but we still use the `elementtree` implementation from the standard library.

FYI @Rotonen @deiferni @maethu @buchi 