### PR TITLE
Use latest "six" version.

### DIFF
--- a/hotfixes/4.0.1.cfg
+++ b/hotfixes/4.0.1.cfg
@@ -28,3 +28,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.10.cfg
+++ b/hotfixes/4.0.10.cfg
@@ -18,3 +18,8 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.2.cfg
+++ b/hotfixes/4.0.2.cfg
@@ -28,3 +28,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.3.cfg
+++ b/hotfixes/4.0.3.cfg
@@ -28,3 +28,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.4.cfg
+++ b/hotfixes/4.0.4.cfg
@@ -26,3 +26,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.5.cfg
+++ b/hotfixes/4.0.5.cfg
@@ -26,3 +26,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.6.1.cfg
+++ b/hotfixes/4.0.6.1.cfg
@@ -24,3 +24,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.6.cfg
+++ b/hotfixes/4.0.6.cfg
@@ -26,3 +26,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.7.cfg
+++ b/hotfixes/4.0.7.cfg
@@ -24,3 +24,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.8.cfg
+++ b/hotfixes/4.0.8.cfg
@@ -22,3 +22,8 @@ Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.9.cfg
+++ b/hotfixes/4.0.9.cfg
@@ -22,3 +22,8 @@ Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.0.cfg
+++ b/hotfixes/4.0.cfg
@@ -28,3 +28,8 @@ Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20110622 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.1.1.cfg
+++ b/hotfixes/4.1.1.cfg
@@ -18,3 +18,8 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.1.2.cfg
+++ b/hotfixes/4.1.2.cfg
@@ -18,3 +18,8 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.1.3.cfg
+++ b/hotfixes/4.1.3.cfg
@@ -18,3 +18,8 @@ Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.1.4.cfg
+++ b/hotfixes/4.1.4.cfg
@@ -16,3 +16,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.1.5.cfg
+++ b/hotfixes/4.1.5.cfg
@@ -16,3 +16,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.1.6.cfg
+++ b/hotfixes/4.1.6.cfg
@@ -16,3 +16,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.1.cfg
+++ b/hotfixes/4.1.cfg
@@ -22,3 +22,8 @@ Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
 Products.Zope_Hotfix_20111024 = 1.0
 Products.Zope_Hotfix_CVE_2010_3198 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.1.cfg
+++ b/hotfixes/4.2.1.cfg
@@ -16,3 +16,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.2.cfg
+++ b/hotfixes/4.2.2.cfg
@@ -16,3 +16,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.3.cfg
+++ b/hotfixes/4.2.3.cfg
@@ -14,3 +14,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.4.cfg
+++ b/hotfixes/4.2.4.cfg
@@ -14,3 +14,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.5.cfg
+++ b/hotfixes/4.2.5.cfg
@@ -14,3 +14,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.6.cfg
+++ b/hotfixes/4.2.6.cfg
@@ -12,3 +12,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.7.cfg
+++ b/hotfixes/4.2.7.cfg
@@ -12,3 +12,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.2.cfg
+++ b/hotfixes/4.2.cfg
@@ -16,3 +16,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.1.cfg
+++ b/hotfixes/4.3.1.cfg
@@ -14,3 +14,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.10.cfg
+++ b/hotfixes/4.3.10.cfg
@@ -4,3 +4,8 @@ hotfix-eggs =
 
 
 [versions]
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.11.cfg
+++ b/hotfixes/4.3.11.cfg
@@ -4,3 +4,8 @@ hotfix-eggs =
 
 
 [versions]
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.2.cfg
+++ b/hotfixes/4.3.2.cfg
@@ -12,3 +12,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.3.cfg
+++ b/hotfixes/4.3.3.cfg
@@ -10,3 +10,8 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.4.cfg
+++ b/hotfixes/4.3.4.cfg
@@ -10,3 +10,8 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.5.cfg
+++ b/hotfixes/4.3.5.cfg
@@ -10,3 +10,8 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.6.cfg
+++ b/hotfixes/4.3.6.cfg
@@ -10,3 +10,8 @@ hotfix-eggs =
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.7.cfg
+++ b/hotfixes/4.3.7.cfg
@@ -8,3 +8,8 @@ hotfix-eggs =
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.8.cfg
+++ b/hotfixes/4.3.8.cfg
@@ -6,3 +6,8 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.9.cfg
+++ b/hotfixes/4.3.9.cfg
@@ -6,3 +6,8 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.cfg
+++ b/hotfixes/4.3.cfg
@@ -14,3 +14,8 @@ Products.PloneHotfix20131210 = 1.0
 Products.PloneHotfix20150910 = 1.1
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/5.0.2.cfg
+++ b/hotfixes/5.0.2.cfg
@@ -6,3 +6,8 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/5.0.3.cfg
+++ b/hotfixes/5.0.3.cfg
@@ -6,3 +6,8 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/5.0.4.cfg
+++ b/hotfixes/5.0.4.cfg
@@ -6,3 +6,8 @@ hotfix-eggs =
 
 [versions]
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/5.0.5.cfg
+++ b/hotfixes/5.0.5.cfg
@@ -4,3 +4,8 @@ hotfix-eggs =
 
 
 [versions]
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/5.0.6.cfg
+++ b/hotfixes/5.0.6.cfg
@@ -4,3 +4,8 @@ hotfix-eggs =
 
 
 [versions]
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/5.0.cfg
+++ b/hotfixes/5.0.cfg
@@ -8,3 +8,8 @@ hotfix-eggs =
 [versions]
 Products.PloneHotfix20151208 = 1.0
 Products.PloneHotfix20160419 = 1.0
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/update.py
+++ b/hotfixes/update.py
@@ -15,6 +15,13 @@ BLACKLIST = (
     'Products.PloneHotfix20160830',
 )
 
+STATIC_VERSIONS_TEXT = '''
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0
+'''
+
 
 def update_hotfixes_files():
     hotfixes = load_hotfixes()
@@ -39,6 +46,8 @@ def update_hotfixes_files():
             for package in map(itemgetter('package'), proposed):
                 hotfix_version = get_hotfix_version(package)
                 fileio.write('{} = {}\n'.format(package, hotfix_version))
+
+            fileio.write(STATIC_VERSIONS_TEXT)
 
 
 def load_hotfixes():

--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -12,8 +12,5 @@ splinter = 0.6.0
 
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
 zc.buildout= >2
+setuptools=
 distribute=
-
-# setuptools 34.0.0 unbundles six and adds a version constraint which is
-# incompatible Plone KGS.
-setuptools = 33.1.1


### PR DESCRIPTION
~~🚧 Depends on / includes #66~~

Use latest ``six`` version in order to avoid version conflict
since ``setuptools`` requires the latest ``six`` version but
older Plone KGS pin older ``six`` versions.

FYI @Rotonen @deiferni @maethu @buchi