### PR TITLE
Pin down setuptools to 33.1.1 again because of issues with six and pip.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -12,5 +12,10 @@ splinter = 0.6.0
 
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
 zc.buildout= >2
-setuptools=
 distribute=
+
+# setuptools 34.0.0 unvendors six (#933) and adds a version constraint which is
+# incompatible Plone KGS.
+# Additionally, setuptools 34.0.2 seems to cause issues with older versions
+# of pip (#945)
+setuptools = 33.1.1


### PR DESCRIPTION
`setuptools 34.0.0` unvendors six (pypa/setuptools#933) and adds a version constraint which is incompatible Plone KGS. We attempted to fix this by bumping the `six` version to a recent one via #67, but this doesn't work yet for all test/dev buildouts.

Additionally, `setuptools 34.0.2` seems to cause issues with older versions of `pip` (pypa/setuptools#945), also causing issues in our CI (https://ci.4teamwork.ch/builds/56302/tasks/80165)

@jone