### PR TITLE
Improve setup for formatting XMLs

### DIFF
--- a/format-xml
+++ b/format-xml
@@ -47,7 +47,8 @@ XML_ATTRIBUTES_ALWAYS_MULTILINE = (
 
 class Indenter(object):
 
-    def __call__(self, paths):
+    def __call__(self, paths, check_only):
+        self.check_only = check_only
         return map(self.format_file_inplace, paths)
 
     def format_file_inplace(self, path):
@@ -56,6 +57,12 @@ class Indenter(object):
 
         new_xml = self.format_xml_string(original_xml).rstrip() + '\n'
         is_unchanged = new_xml == original_xml
+        if self.check_only:
+            if not is_unchanged:
+                print '>', path, 'changed'
+
+            return is_unchanged
+
         print '>', path, '({0})'.format(
             'unchanged' if is_unchanged else 'changed')
         with open(path, 'w') as fio:
@@ -233,6 +240,6 @@ if __name__ == '__main__':
                              'state if a file was changed.')
 
     args = parser.parse_args()
-    unchanged = Indenter()(args.paths)
+    unchanged = Indenter()(args.paths, args.check)
     if args.check and not all(unchanged):
         sys.exit(1)

--- a/format-xml
+++ b/format-xml
@@ -2,16 +2,19 @@
 
 import imp
 import os
+import pkg_resources
 import sys
 import tempfile
 
-# Load sys.path from zopepy
-ori_args = sys.argv[:]
-with tempfile.NamedTemporaryFile() as empty_file:
-    sys.argv[1:] = [empty_file.name]
-    imp.load_source('zopepy', os.path.join(os.path.dirname(__file__), 'zopepy'))
-    sys.argv = ori_args
-
+try:
+    pkg_resources.get_distribution('lxml')
+except pkg_resources.DistributionNotFound:
+    # Load sys.path from zopepy
+    ori_args = sys.argv[:]
+    with tempfile.NamedTemporaryFile() as empty_file:
+        sys.argv[1:] = [empty_file.name]
+        imp.load_source('zopepy', os.path.join(os.path.dirname(__file__), 'zopepy'))
+        sys.argv = ori_args
 
 from lxml import etree
 from StringIO import StringIO

--- a/format-xml.cfg
+++ b/format-xml.cfg
@@ -1,0 +1,43 @@
+[buildout]
+parts += ${buildout:format-xml-parts}
+format-xml-parts =
+    format-xml
+    download-format-xml
+    format-all-xmls
+
+
+[format-xml]
+recipe = zc.recipe.egg:scripts
+eggs =
+    lxml
+    argparse
+
+interpreter = format-xml
+dependent-scripts = false
+initialization = sys.argv.insert(1, "${download-format-xml:destination}/format-xml")
+
+
+[download-format-xml]
+recipe = hexagonit.recipe.download
+# Be aware that this is cached in downloads cache:
+# you need to change the URL in order the get a new version.
+# Therefore the git-hash is included in the URL.
+url = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/d164042/format-xml
+download-only = true
+destination = ${buildout:parts-directory}/format-xml
+mode = 0755
+on-update = True
+
+
+[format-all-xmls]
+recipe = collective.recipe.template
+output = ${buildout:directory}/bin/format-all-xmls
+mode = 0755
+input = inline:
+    #!/usr/bin/env sh
+    set -euo pipefail
+    IFS=$'\n'
+    pkgdir=$(${buildout:bin-directory}/package-directory)
+    formatter="${buildout:bin-directory}/format-xml"
+    $formatter $(find $pkgdir \! -path "*/upgrades/*" -type f \( -iname \*.xml -o -iname \*.zcml \)) "$@"
+    exit $?

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -13,14 +13,14 @@
 
 
 [buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/format-xml.cfg
 parts +=
     instance
     zopepy
     i18n-build
     upgrade
     omelette
-    format-xml
-    format-all-xmls
 
 i18n-domain = ${buildout:package-namespace}
 
@@ -91,25 +91,3 @@ package-namespace = ${buildout:package-namespace}
 [upgrade]
 recipe = zc.recipe.egg:script
 eggs = ftw.upgrade
-
-
-[format-xml]
-recipe = hexagonit.recipe.download
-url = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/format-xml
-download-only = true
-destination = ${buildout:bin-directory}
-mode = 0755
-on-update = True
-
-[format-all-xmls]
-recipe = collective.recipe.template
-output = ${buildout:directory}/bin/format-all-xmls
-mode = 0755
-input = inline:
-    #!/usr/bin/env sh
-    set -euo pipefail
-    IFS=$'\n'
-    pkgdir=$(${buildout:bin-directory}/package-directory)
-    formatter="${buildout:bin-directory}/format-xml"
-    $formatter $(find $pkgdir \! -path "*/upgrades/*" -type f \( -iname \*.xml -o -iname \*.zcml \)) "$@"
-    exit $?

--- a/test-xmls-formatted.cfg
+++ b/test-xmls-formatted.cfg
@@ -1,0 +1,25 @@
+[buildout]
+extends =
+    ./test-base.cfg
+    ./format-xml.cfg
+
+parts =
+    package-directory
+    ${buildout:format-xml-parts}
+    test-jenkins
+
+jenkins_python = $PYTHON27
+
+
+[test-jenkins]
+recipe = collective.recipe.template
+output = ${buildout:bin-directory}/test-jenkins
+mode = 755
+input = inline:
+    #!/bin/bash
+    set -euo pipefail
+
+    BUILD_LOG="format_all_xmls.log"
+
+    ${buildout:bin-directory}/format-all-xmls --check 2>&1 | tee $BUILD_LOG
+    exit $?


### PR DESCRIPTION
**Goal:**
Be able to run a test in Jenkins, which tells when there are incorrectly formatted XMLs in the project.

**Changes:**
- `format-xml`-Script: make it run with any interpreter, load `bin/zopepy` as fallback.
- `format-xml`-Script: let `--check` no longer change the files but only tell wether there are unformatted files.
- Extract the format-xml buildout setup into a separate `format-xml.cfg`.
  - Change the new buildouts so that the script is now downloaded into `./parts` and a python-script with `lxml` installed is used for running the script.
- Update `plone-development.cfg`, so that it uses the new `format-xml.cfg`.
- Add new `test-xmls-formatted.cfg`, testing whether the XMLs are formatted well.

**Example for XML formatting tests:**
`test-xml-formatted.cfg`
```
[buildout]
extends = /Users/jone/projects/packages/ftw-buildouts/test-xmls-formatted.cfg
package-name = opengever.core
package-namespace = opengever
```

@maethu can you take a look a this one?
It should not break any existing behavior.