### PR TITLE
remove format-xml from plone development.

### DIFF
--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -13,8 +13,6 @@
 
 
 [buildout]
-extends =
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/format-xml.cfg
 parts +=
     instance
     zopepy


### PR DESCRIPTION
The problem is that buildout sucks.
We cannot add an extends here because the tree is then fucked up and things will be deleted.

😡 