### PR TITLE
Avoid testing against Plone 4.3.12.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,6 +1,17 @@
 [buildout]
 extends =
-    http://dist.plone.org/release/4.3-latest/versions.cfg
+
+# The Plone KGS 4.3.12 bumps plone.app.ugprade to 2.x, where it no longer
+# requires Products.SecureMailHost.
+# But Products.SecureMailHost is still tried to be loaded by
+# plone.app.testing, resulting in a lot of broken builds.
+
+# As of https://community.plone.org/t/plone-4-3-12-soft-released/3529/14
+# this will be adressed in 4.3.13.
+
+# Therefore it is easiest to wait for 4.3.13.
+#    http://dist.plone.org/release/4.3-latest/versions.cfg
+    http://dist.plone.org/release/4.3.11/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
 


### PR DESCRIPTION
The Plone KGS 4.3.12 bumps plone.app.ugprade to 2.x, where it no longer requires Products.SecureMailHost.
But Products.SecureMailHost is still tried to be loaded by plone.app.testing, resulting in a lot of broken builds.

As of https://community.plone.org/t/plone-4-3-12-soft-released/3529/14 this will be adressed in 4.3.13.

Therefore it is easiest to wait for 4.3.13.