### PR TITLE
Pin zope.app.container.

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -355,6 +355,11 @@ collective.xmltestreport = 1.2.6
 # this will usually be changed by a plone- or zope-kgs.
 zope.security = 3.8.3
 
+# This is for packages with a unpinned zope.app.container dependency.
+# With zope.app.container 4.0.0 they introduced Python 3 support and now depend on zope.security > 4.1.
+# zope.security 4.x is not Plone 4.x nor 5.x compatible.
+zope.app.container = 3.9.2
+
 
 # csselect 0.7.1 is not compatible with the newest pyquery version.
 # since we are using pyquery in tests a lot, and usually neither pyquery nor cssselect is pinned,


### PR DESCRIPTION
This is for packages with a unpinned zope.app.container dependency.
With zope.app.container 4.0.0 they introduced Python 3 support and now depend on
zope.security > 4.1.

zope.security 4.x is not Plone 4.x nor 5.x compatible.
zope.app.container = 3.9.2

PR is open https://github.com/collective/collective.jsonmigrator/pull/25
