### PR TITLE
Do not run dependencychecker on CI runs

### DIFF
--- a/test-package.cfg
+++ b/test-package.cfg
@@ -42,11 +42,6 @@ input = inline:
     bin/check-translations | sed -e 's/>/\&gt;/' -e 's/</\&lt;/' >> ${buildout:results-dir}/translations.html
     echo "</pre>" >> ${buildout:results-dir}/translations.html
 
-    echo "check dependencies > ${buildout:results-dir}/dependencies.html"
-    echo "<pre>" > ${buildout:results-dir}/dependencies.html
-    bin/dependencychecker | sed -e 's/>/\&gt;/' -e 's/</\&lt;/' >> ${buildout:results-dir}/dependencies.html
-    echo "</pre>" >> ${buildout:results-dir}/dependencies.html
-
     ${test-jenkins:pre-test}
     ${test-jenkins:test-command}
     result=$?


### PR DESCRIPTION
Currently running this in our CI builds merely wastes almost a minute of time per run.