### PR TITLE
Pin Chameleon to 2.25.

### DIFF
--- a/chameleon.cfg
+++ b/chameleon.cfg
@@ -20,3 +20,6 @@ eggs += ftw.chameleon
 initialization +=
     import os
     if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = '${buildout:chameleon-cache}'
+
+[versions]
+Chameleon = 2.25


### PR DESCRIPTION
3.1 lacks some features Plone uses in it's default templates.

For example the base_edit form of AT throws the following error:
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 31, in _call
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.CMFCore.FSPageTemplate, line 237, in _exec
  Module Products.CMFCore.FSPageTemplate, line 177, in pt_render
  Module Products.PageTemplates.PageTemplate, line 79, in pt_render
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 58a27cc2914c3b67ff1c8c0d0ef17bee, line 93, in render
  Module 48d0f9bec64bab24608ea2a7c2c0f0a9, line 792, in render_master
  Module 6f99b95aa425b867a333aaee02763135, line 954, in render_master
  Module 48d0f9bec64bab24608ea2a7c2c0f0a9, line 528, in __fill_javascript_head_slot
  Module chameleon.compiler, line 641, in __call__
  Module chameleon.compiler, line 945, in __init__
  Module chameleon.compiler, line 961, in visit
  Module chameleon.compiler, line 1001, in visit_Module
  Module chameleon.compiler, line 961, in visit
  Module chameleon.compiler, line 1036, in visit_Context
  Module chameleon.compiler, line 961, in visit
  Module chameleon.compiler, line 1193, in visit_Assignment
  Module chameleon.compiler, line 753, in __call__
  Module chameleon.compiler, line 795, in translate
  Module chameleon.compiler, line 807, in visit_Value
  Module chameleon.compiler, line 582, in assign_value
  Module chameleon.compiler, line 502, in compiler
  Module chameleon.tales, line 497, in __call__
  Module chameleon.compiler, line 582, in assign_value
  Module chameleon.compiler, line 502, in compiler
  Module chameleon.tales, line 144, in __call__
  Module chameleon.tales, line 185, in translate_proxy
  Module z3c.pt.expressions, line 223, in translate
  Module z3c.pt.expressions, line 163, in translate
ExpressionError: Not a valid path-expression.

 - String:     "nocall:portal/."
 - Location:   (line 0: col 0)

 - Expression: "here/base_edit/macros/master"
 - Filename:   ... oducts/ATContentTypes/skins/ATContentTypes/atct_edit.cpt
 - Location:   (line 1: col 29)
 - Source:     ... n metal:use-macro="here/base_edit/macros/master" />
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ImplicitAcquisitionWrapper atct_edit at 0x1165dd370>
               modules: <instance - at 0x1063cce18>
               here: <ImplicitAcquisitionWrapper file1 at 0x1165dd550>
               user: <ImplicitAcquisitionWrapper - at 0x1165dd3c0>
               nothing: <NoneType - at 0x10015fab8>
               container: <ImplicitAcquisitionWrapper file1 at 0x1165dd550>
               default: <object - at 0x100298bf0>
               request: <instance - at 0x112e84758>
               wrapped_repeat: <SafeMapping - at 0x1154f7d60>
               traverse_subpath: <list - at 0x1153d18c0>
               loop: {...} (1)
               context: <ImplicitAcquisitionWrapper file1 at 0x1165dd550>
               translate: <function translate at 0x1143bbcf8>
               root: <ImplicitAcquisitionWrapper Zope at 0x10f981b40>
               options: {...} (2)
               target_language: <NoneType - at 0x10015fab8>
```  

Also affected is PloneFormGen and CMFEditions. 