### PR TITLE
Reduce += assignments to parts option.

### DIFF
--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -1,8 +1,6 @@
 # A buildout base configuration for plone development.
 # Parts:
 # bin/instance : The zope instance.
-# bin/test : Test runner, testing the package defined in ${buildout:package-name}.
-# bin/test-coverage : Test runner with coverage report.
 # parts/omelette : Omelette with instance and test eggs.
 #
 # Example usage:

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -1,4 +1,5 @@
-# A buildout base configuration for plone development.
+# A buildout base configuration for plone development. Must also extend from
+# a test buildout configuration file.
 # Parts:
 # bin/instance : The zope instance.
 # parts/omelette : Omelette with instance and test eggs.
@@ -6,17 +7,21 @@
 # Example usage:
 # [buildout]
 # extends =
+#     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-x.y.z.cfg
 #     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 # package-name = my.package
 
 
 [buildout]
-parts +=
+development-parts =
     instance
     zopepy
     i18n-build
     upgrade
     omelette
+
+parts +=
+    ${buildout:development-parts}
 
 i18n-domain = ${buildout:package-namespace}
 

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -31,19 +31,31 @@ package-namespace = ${buildout:package-name}
 # The "early-parts" option let late configs inject parts at the beginning.
 early-parts =
 
-parts =
-    ${buildout:early-parts}
+tool-parts =
+    package-directory
+    dependencychecker
+
+test-parts =
     test
     test-coverage
-    package-directory
     coverage
+
+code-audit-parts =
     pep8-cfg
     pep8
     pyflakes
     zptlint
+
+i18n-parts =
     i18ndude
     check-translations
-    dependencychecker
+
+parts =
+    ${buildout:early-parts}
+    ${buildout:tool-parts}
+    ${buildout:test-parts}
+    ${buildout:code-audit-parts}
+    ${buildout:i18n-parts}
 
 # We assume that the buildout directory is the package root (repository root)
 # of the package we are testing.

--- a/test-package.cfg
+++ b/test-package.cfg
@@ -5,7 +5,7 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-base.cfg
 
-parts +=
+test-parts +=
     test-jenkins
 
 # mr.developer defaults for testing buildouts


### PR DESCRIPTION
Buildout has problems with += and -= operations to an option in combination with exceeding a certain nesting level of extends. In a desperate approach this commit reduces the number of += assignments to parts and also provides other options to assign to.

There are open pull-requests in buildout itself that would address this issue, but they have been open for quite a while now. So we'll have to attempt work around the problem for now _(i.e. most likely the next few years 😠 )_. See https://github.com/buildout/buildout/pull/226 or https://github.com/buildout/buildout/pull/22.