### PR TITLE
Pylint distribute issues are no more

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -382,14 +382,6 @@ cssselect = 0.9
 # Latest keyring releases 5.0, 5.1, 5.2 and 5.2.1 are not compatible, since they require a specific setuptools version.
 keyring = 4.1.1
 
-# pylint > 0.25.2 is not distribute compatible. It does only register the
-# console_scripts entry points when setuptools is there - but we usually use
-# distribute now.
-# This results in zc.buildout incompatible scripts generation.
-# Also: in 0.26.0 the script internals have changed so that our configuration
-# does not work anymore.
-pylint = 0.25.2
-
 # Pin pyquery to 1.2.9, since the latest release 1.2.10 requires a newer version of cssselect, which is pinned to 0.7.1 by
 # http://download.zope.org/zopetoolkit/index/1.0.8/ztk-versions.cfg. pyquery 1.2.10 requires at least cssselect 0.7.9.
 pyquery = 1.2.9


### PR DESCRIPTION
On general principles we do not want to pin code quality tools.