### PR TITLE
Use latest plone 4.3.x version in 4.3.x test buildout.

### DIFF
--- a/test-plone-4.3.14.cfg
+++ b/test-plone-4.3.14.cfg
@@ -1,0 +1,13 @@
+[buildout]
+extends =
+    http://dist.plone.org/release/4.3.14/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+
+jenkins_python = $PYTHON27
+
+
+
+[test]
+eggs +=
+    Pillow

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,17 +1,7 @@
 [buildout]
 extends =
 
-# The Plone KGS 4.3.12 bumps plone.app.ugprade to 2.x, where it no longer
-# requires Products.SecureMailHost.
-# But Products.SecureMailHost is still tried to be loaded by
-# plone.app.testing, resulting in a lot of broken builds.
-
-# As of https://community.plone.org/t/plone-4-3-12-soft-released/3529/14
-# this will be adressed in 4.3.13.
-
-# Therefore it is easiest to wait for 4.3.13.
-#    http://dist.plone.org/release/4.3-latest/versions.cfg
-    http://dist.plone.org/release/4.3.11/versions.cfg
+    http://dist.plone.org/release/4.3-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
 


### PR DESCRIPTION
As discussed last week ...

The version 4.3.12 was skipped with #75 because of an issue with `plone.app.ugprade` and `plone.app.testing` versions. This issue was addressed in `4.3.13`, so the newest version (already `4.3.14`) should be used for testing.