### PR TITLE
Add production.cfg addition for production deployments which uses relstorage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -330,11 +330,44 @@ Example:
     deployment-number = 05
 
 
+Relstorage
+~~~~~~~~~~
+When including ``production-relstorage.cfg`` as the example shows below, no
+ZEO Server and filestorage will be installed. Besides that, the relstorage will
+be configured according to the relstorage buildout variables. The Following
+variables have to be defined in the buildout section:
+
+- relstorage-type
+- relstorage-user
+- relstorage-pw
+- relstorage-shared-blob-dir
+- relstorage-commit-lock-id
+- relstorage-blob-cache-size
+
+
+Example:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
+        https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production-relstorage.cfg
+
+    relstorage-type = oracle
+    relstorage-user = user1
+    relstorage-pw = secure
+    relstorage-blob-cache-size = 1gb
+    relstorage-shared-blob-dir = false
+    relstorage-commit-lock-id = 7
+
+
+
 ZODB Replicated Storage (ZRS)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Including ``zrs-primary.cfg`` configures the ZEO server as primary storage listening
-on port ``1XX21``. 
+on port ``1XX21``.
 
 Example:
 

--- a/production-relstorage.cfg
+++ b/production-relstorage.cfg
@@ -1,0 +1,36 @@
+# Addition to the production.cfg for deployments which use relstorage.
+# Drops filestorage and zeo part
+
+# The following variables have to be defined in the buildout section
+#  - relstorage-type
+#  - relstorage-user
+#  - relstorage-pw
+#  - relstorage-shared-blob-dir
+#  - relstorage-commit-lock-id
+#  - (relstorage-blob-cache-size)
+
+
+[buildout]
+parts -=
+    filestorage
+    zeo
+
+instance-eggs += RelStorage
+
+[supervisor]
+program-zeo =
+
+[instance0]
+zeo-client = off
+zeo-address =
+
+relstorage-blob-cache-size = 1gb
+
+rel-storage =
+    type ${buildout:relstorage-type}
+    user ${buildout:relstorage-user}
+    password ${buildout:relstorage-pw}
+    blob-dir ${buildout:directory}/var/blobcache/${:_buildout_section_name_}
+    shared-blob-dir ${buildout:relstorage-shared-blob-dir}
+    blob-cache-size ${buildout:relstorage-blob-cache-size}
+    commit-lock-id ${buildout:relstorage-commit-lock-id}

--- a/production.cfg
+++ b/production.cfg
@@ -124,8 +124,10 @@ port = 127.0.0.1:1${buildout:deployment-number}99
 user = supervisor
 password = admin
 
+program-zeo = 10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} true
+
 programs =
-    10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} true
+    ${supervisor:program-zeo}
     90 instance0 (${buildout:supervisor-client-process-opts} autostart=false) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
     20 instance1 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
 


### PR DESCRIPTION
The new `production-relstorage.cfg` configuration file is intended as addition to the existing `production.cfg`, for example a buildout.cfg could look like this:

```
[buildout]
extends =
    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production.cfg
    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production-relstorage.cfg
    ...

[instance0]
relstorage-type = oracle
relstorage-user = OG_xx
relstorage-pw = xxx
relstorage-shared-blob-dir = false
relstorage-commit-lock-id = 12
```