### PR TITLE
Fix _strptime race condition in p.r.zope2instance based instances

### DIFF
--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -63,6 +63,11 @@ zcml-additional =
         ${buildout:zcml-additional-fragments}
     </configure>
 
+initialization =
+    # Import _strptime before starting any threads to avoid race condition.
+    # See http://bugs.python.org/issue7980
+    import _strptime
+
 
 [omelette]
 # parts/omlette

--- a/production.cfg
+++ b/production.cfg
@@ -108,6 +108,10 @@ zcml-additional =
 
 zope-conf-additional = datetime-format international
 environment-vars = ${buildout:environment-vars}
+initialization =
+    # Import _strptime before starting any threads to avoid race condition.
+    # See http://bugs.python.org/issue7980
+    import _strptime
 
 
 


### PR DESCRIPTION
There is an unfixed **race condition** in Python around the very first import of the `_strptime` C module: That import **isn't thread safe**, and if two threads happen to trigger this lazy import at the same time, the interpreter crashes.

See http://bugs.python.org/issue7980

The **workaround** for this issue is to import `_strptime` before any threads are started, while the application is still single-threaded.
We therefore address this here by triggering the import in the `initialization` section of `plone.recipe.zope2instance` based instances.

---

For the curious: The issue can be reproduced as follows (pure Python, outside a Plone context):

**`strptime_race_condition.py`**
```python
import time
import unittest
import threading


class StressTimeStrptime(threading.Thread):
    def run(self):
        self.error_raised = False
        try:
            for m in range(1, 13):
                for d in range(1, 29):
                    time.strptime("2010%02d%02d" % (m, d), "%Y%m%d")
        except AttributeError:
            self.error_raised = True


class TestStrptimeAttributeInThread(unittest.TestCase):
    def test_run_in_thread(self):
        threads = [StressTimeStrptime() for _ in range(10)]
        for t in threads:
            t.start()
        for t in threads:
            t.join()
            self.assertFalse(
                t.error_raised,
                'should not raise AttributeError for strptime')


def test_main():
    unittest.main()

if __name__ == "__main__":
    test_main()
```

```bash
python -m timeit -s 'import os' 'os.system("strptime_race_condition.py")'
```

Should result in about 1 out of 10 failures like this:

```
======================================================================
FAIL: test_run_in_thread (__main__.TestStrptimeAttributeInThread)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "strptime_race_condition.py", line 27, in test_run_in_thread
    self.assertFalse(t.error_raised, 'should not raise AttributeError for strptime')
AssertionError: should not raise AttributeError for strptime
```

This test case can then be fixed by simply adding `import _strptime` at the top of the module.