### PR TITLE
Allow group to write downloaded files.

### DIFF
--- a/plone-development-tika.cfg
+++ b/plone-development-tika.cfg
@@ -27,6 +27,7 @@ url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.ja
 md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
 filename = tika-app.jar
+mode = 664
 
 
 [tika-server-download]
@@ -35,9 +36,11 @@ url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-
 md5sum = 0f70548f233ead7c299bf7bc73bfec26
 download-only = true
 filename = tika-server.jar
+mode = 664
 
 
 [tika-server]
 recipe = collective.recipe.scriptgen
 cmd = java
 arguments = -jar ${tika-server-download:destination}/${tika-server-download:filename} --port ${tika:server-port}
+mode = 664

--- a/redis/base.cfg
+++ b/redis/base.cfg
@@ -35,6 +35,7 @@ strip-top-level-dir = true
 url = http://download.redis.io/releases/redis-${redis-settings:redis-version}.tar.gz
 md5sum = ${redis-settings:redis-md5sum}
 destination = ${buildout:parts-directory}/redis-${redis-settings:redis-version}
+mode = 664
 
 
 [redis-build]

--- a/solr-base.cfg
+++ b/solr-base.cfg
@@ -39,6 +39,7 @@ recipe = hexagonit.recipe.download
 url = https://archive.apache.org/dist/lucene/solr/${solr-settings:solr-dist-version}/solr-${solr-settings:solr-dist-version}.tgz
 md5sum = ${solr-settings:solr-dist-md5sum}
 strip-top-level-dir = true
+mode = 664
 
 
 [solr-instance]

--- a/tika-jaxrs-remote.cfg
+++ b/tika-jaxrs-remote.cfg
@@ -34,3 +34,4 @@ url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.ja
 md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
 filename = ${tika:filename-app}
+mode = 664

--- a/tika-jaxrs-server.cfg
+++ b/tika-jaxrs-server.cfg
@@ -27,6 +27,7 @@ url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.ja
 md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
 filename = ${tika:filename-app}
+mode = 664
 
 
 [tika-server-download]
@@ -36,6 +37,7 @@ url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-
 md5sum = 0f70548f233ead7c299bf7bc73bfec26
 download-only = true
 filename = ${tika:filename-server}
+mode = 664
 
 
 [tika-server]

--- a/tika-jaxrs-standalone.cfg
+++ b/tika-jaxrs-standalone.cfg
@@ -46,6 +46,7 @@ url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-
 md5sum = 0f70548f233ead7c299bf7bc73bfec26
 download-only = true
 filename = ${buildout:tika-filename-server}
+mode = 664
 
 
 

--- a/tika-server.cfg
+++ b/tika-server.cfg
@@ -23,6 +23,7 @@ url = https://archive.apache.org/dist/tika/tika-app-1.5.jar
 md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
 filename = tika.jar
+mode = 664
 
 
 [tika-server]


### PR DESCRIPTION
Let the owner group have write access to downloaded files so that we can run buildout with multiple users.