### PR TITLE
Add production-v2.cfg for new style deployments.

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -1,0 +1,30 @@
+# New style of deployments:
+# - increased security through support for multiple users
+# - deployments are now located at /apps/0x-plone-y
+# - the groups "deploy" and "zope" make sure every user has the right access
+#   to the files
+# - files are owned by the deploying user and the service user (zope) does not
+#   have write access to the source code and other files
+# - files which are written by the service user (zope), such as the database,
+#   are owned by the zope group.
+#
+# Usage:
+# This config file must be extended after extending the production.cfg.
+# It is not a replacement for the production.cfg but an extension.
+
+[buildout]
+parts += setpermissions
+
+
+[deployment]
+etc-directory = /apps/etc
+
+
+[setpermissions]
+# Make sure that the var directory is owned by the "zope" group in order to
+# let the service user "zope" have write access.
+recipe = plone.recipe.command
+command =
+    chgrp -R zope ${buildout:directory}/var
+    find ${buildout:directory}/var -maxdepth 1 -type d -exec chmod 2770 {} \;
+update-command = ${:command}


### PR DESCRIPTION
New style of deployments:
increased security through support for multiple users
- deployments are now located at /apps/0x-plone-y
- the groups "deploy" and "zope" make sure every user has the right access
  to the files
- files are owned by the deploying user and the service user (zope) does not
  have write access to the source code and other files
- files which are written by the service user (zope), such as the database,
 are owned by the zope group.

Usage:
This config file must be extended after extending the production.cfg.
It is not a replacement for the production.cfg but an extension.