### PR TITLE
Separate the normal pycodestyle entry point from the ci run parametres

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -41,8 +41,9 @@ test-parts =
     coverage
 
 code-audit-parts =
-    pycodestyle-cfg
     pycodestyle
+    pycodestyle-cfg
+    pycodestyle-ci-run
     pyflakes
     zptlint
 
@@ -189,6 +190,9 @@ output = ${buildout:directory}/bin/package-directory
 mode = 755
 
 
+[pycodestyle]
+recipe = zc.recipe.egg:scripts
+eggs = pycodestyle
 
 # Downloads the default pycodestyle.cfg.
 [pycodestyle-cfg]
@@ -196,27 +200,17 @@ recipe = collective.recipe.shelloutput
 cfgfile = ${buildout:directory}/parts/pycodestyle/pycodestyle.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pycodestyle.cfg
 commands =
-    cmd1 = mkdir -p `dirname ${pycodestyle-cfg:cfgfile}`
+    cmd1 = mkdir -p $(dirname ${pycodestyle-cfg:cfgfile})
     cmd2 = curl "${pycodestyle-cfg:cfgurl}" > "${pycodestyle-cfg:cfgfile}"
 
+[pycodestyle-ci-run]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/bash
+    bin/pycodestyle --exclude=tests --config="${pycodestyle-cfg:cfgfile}" $(bin/package-directory relative)
 
-
-# bin/pycodestyle : pycodestyle validation of the packages source.
-[pycodestyle]
-recipe = zc.recipe.egg
-eggs = pycodestyle
-args = ['--exclude=tests', '--config=${pycodestyle-cfg:cfgfile}']
-initialization =
-    import os
-    import subprocess
-    os.chdir("${buildout:directory}")
-    pkgdir = subprocess.Popen(
-        '${buildout:directory}/bin/package-directory relative',
-        shell=True, stdout=subprocess.PIPE).stdout.read().strip()
-    if '--absolute' in sys.argv: pkgdir = os.path.abspath(pkgdir) ; sys.argv.remove('--absolute')
-    if len(sys.argv) < 2: sys.argv.extend([pkgdir])
-    sys.argv.extend(${pycodestyle:args})
-
+output = ${buildout:bin-directory}/pycodestyle-ci-run
+mode = 755
 
 # bin/pyflakes : Pyflakes validation of the packages source.
 [pyflakes]

--- a/test-package.cfg
+++ b/test-package.cfg
@@ -28,8 +28,8 @@ test-command = ${test-jenkins:test-command-no-coverage}
 input = inline:
     #!/bin/sh
     mkdir -p ${buildout:results-dir}
-    echo "pycodestyle -> ${buildout:results-dir}/pycodestyle.log"
-    bin/pycodestyle | tee ${buildout:results-dir}/pycodestyle.log > /dev/null
+    echo "pycodestyle-ci-run -> ${buildout:results-dir}/pycodestyle.log"
+    bin/pycodestyle-ci-run | tee ${buildout:results-dir}/pycodestyle.log > /dev/null
 
     echo "pyflakes -> ${buildout:results-dir}/pyflakes.log"
     bin/pyflakes | tee ${buildout:results-dir}/pyflakes.log > /dev/null


### PR DESCRIPTION
This allows us to ship a shared config file and also a normal entry point for editor integrations.

I'm not 100% if I lost corner cases with the translation to just a flat shell script.