### PR TITLE
🚧  Add testing variables for package extras.

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -19,8 +19,10 @@
 
 # Configuration variables:
 package-name =
+package-extras =
 
-test-egg = ${buildout:package-name} [tests]
+test-extras = tests ${buildout:package-extras}
+test-egg = ${buildout:package-name} [${buildout:test-extras}]
 package-directory =
 package-namespace = ${buildout:package-name}
 


### PR DESCRIPTION
The new variable ``buildout:package-extras`` can be used in the testing buildout for installing and testing an optional feature of the package under test.

This change also introduces the variable ``buildout:test-extras``, which combines the ``buildout:package-extras`` and the default "tests" extras. It makes it easier to change the behavior for special use cases.