### PR TITLE
Extract test-extras into separate variable.

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -20,7 +20,8 @@
 # Configuration variables:
 package-name =
 
-test-egg = ${buildout:package-name} [tests]
+test-extras = tests
+test-egg = ${buildout:package-name} [${buildout:test-extras}]
 package-directory =
 package-namespace = ${buildout:package-name}
 


### PR DESCRIPTION
Extract the test-extras into ``buildout:test-extras``.
This makes it easy to install extras in tests.

Example:

```ini
[buildout]
...
test-extras = tests,my-feature
```

Using `test-extras +=` cannot work because it concatenates with a `\n`, which is not allowed in the extras bracket.