### PR TITLE
Fix redis make error on fresh download.

### DIFF
--- a/redis/base.cfg
+++ b/redis/base.cfg
@@ -40,8 +40,8 @@ destination = ${buildout:parts-directory}/redis-${redis-settings:redis-version}
 [redis-build]
 recipe = collective.recipe.cmd
 on_install = true
-on_update = false
-cmds = cd ${redis-download:location} && make
+on_update = true
+cmds = cd ${redis-download:location} ; if [ ! -e "src/redis-server" ]; then make; fi
 
 
 [redis-ensure-var-exists]


### PR DESCRIPTION
The redis-download-part downloads a fresh source copy of redis, where redis-build-part compiles the source.
redis-build's on_update was set to false in order to speed up updates where redis is already installed and does not change.

But on certain changes (such as a changed redis buildout file) buildout will reinstall the redis-download part while only running "update" on the redis-build part. Since redis-build will skip we will end up with an uncompiled redis source.

In order to solve this problem we change on_update to true, so that the redis-build part is always executed. For still skipping on an already installed redis, we just probe for the src/redis-server file and only run "make" when the file is missing.

I expect this change to trigger a fresh download / compile on all installations because the redis `redis/base.cfg` has changed.