### PR TITLE
Add localhost to list of trusted proxies by default

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -106,7 +106,10 @@ zcml-additional =
     </configure>
 
 
-zope-conf-additional = datetime-format international
+zope-conf-additional = 
+    datetime-format international
+    trusted-proxy 127.0.0.1
+
 environment-vars = ${buildout:environment-vars}
 initialization =
     # Import _strptime before starting any threads to avoid race condition.


### PR DESCRIPTION
In most cases Zope runs behind a reverse proxy on the same host. In order to
get the real remote IP of clients using `request.getClientAddr()` we need to
add localhost to the list of trusted IPs.