### PR TITLE
production-v2.cfg: Make sure files in /apps/eggs are world-readable.

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -30,5 +30,5 @@ command =
     # Make sure supervisord is always started as "zope" user using sudo.
     chmod --silent u-x ${buildout:directory}/bin/supervisord
     # Make sure that other users can access the egg infos later.
-    chmod -R --silent g+rw /apps/eggs/*
+    chmod -R --silent g+rw,o+r /apps/eggs/*
 update-command = ${:command}


### PR DESCRIPTION
Contents in `/apps/eggs` also need to be world-readable.

Tested manually.