### PR TITLE
Add pydocstyle to our QA toolset

### DIFF
--- a/pydocstyle.cfg
+++ b/pydocstyle.cfg
@@ -1,0 +1,15 @@
+[pydocstyle]
+# D100 Missing docstring in public module
+# D102	Missing docstring in public method
+# D103	Missing docstring in public function
+# D105	Missing docstring in magic method
+# D200	One-line docstring should fit on one line with quotes
+# D203	1 blank line required before class docstring
+# D205	1 blank line required between summary line and description
+# D212	Multi-line docstring summary should start at the first line
+# D213	Multi-line docstring summary should start at the second line
+# D400	First line should end with a period
+# D401	First line should be in imperative mood
+# D404	First word of the docstring should not be This
+add-ignore = D100,D102,D103,D105,D200,D203,D205,D212,D213,D400,D401,D404
+match = (?!(test_|__init__)).*\.py

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -44,6 +44,8 @@ test-parts =
 code-audit-parts =
     pycodestyle-cfg
     pycodestyle
+    pydocstyle-cfg
+    pydocstyle
     pyflakes
     zptlint
 
@@ -218,6 +220,32 @@ initialization =
     if len(sys.argv) < 2: sys.argv.extend([pkgdir])
     sys.argv.extend(${pycodestyle:args})
 
+# Downloads the default pydocstyle.cfg.
+[pydocstyle-cfg]
+recipe = collective.recipe.shelloutput
+cfgfile = ${buildout:directory}/parts/pydocstyle/pydocstyle.cfg
+cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pydocstyle.cfg
+commands =
+    cmd1 = mkdir -p `dirname ${pydocstyle-cfg:cfgfile}`
+    cmd2 = curl "${pydocstyle-cfg:cfgurl}" > "${pydocstyle-cfg:cfgfile}"
+
+
+
+# bin/pydocstyle : pydocstyle validation of the packages source.
+[pydocstyle]
+recipe = zc.recipe.egg
+eggs = pydocstyle
+args = ['--config=${pydocstyle-cfg:cfgfile}']
+initialization =
+    import os
+    import subprocess
+    os.chdir("${buildout:directory}")
+    pkgdir = subprocess.Popen(
+        '${buildout:directory}/bin/package-directory relative',
+        shell=True, stdout=subprocess.PIPE).stdout.read().strip()
+    if '--absolute' in sys.argv: pkgdir = os.path.abspath(pkgdir) ; sys.argv.remove('--absolute')
+    if len(sys.argv) < 2: sys.argv.extend([pkgdir])
+    sys.argv.extend(${pydocstyle:args})
 
 # bin/pyflakes : Pyflakes validation of the packages source.
 [pyflakes]


### PR DESCRIPTION
To mirror our pycodestyle setup, I'd like to introduce a pydocstyle setup to our buildouts as well.