### PR TITLE
Remove old version pinnings from test-base.cfg.

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -363,26 +363,3 @@ scripts = dependencychecker
 [versions]
 # collective.xmltestreport: pinned down because of the z3c.recipe.scripts which results in version conflicts with the zope versions configuration.
 collective.xmltestreport = 1.2.6
-
-# pin down zope.security by default (used by zptlint and i18ndude)
-# this will usually be changed by a plone- or zope-kgs.
-zope.security = 3.8.3
-
-# This is for packages with a unpinned zope.app.container dependency.
-# With zope.app.container 4.0.0 they introduced Python 3 support and now depend on zope.security > 4.1.
-# zope.security 4.x is not Plone 4.x nor 5.x compatible.
-zope.app.container = 3.9.2
-
-
-# csselect 0.7.1 is not compatible with the newest pyquery version.
-# since we are using pyquery in tests a lot, and usually neither pyquery nor cssselect is pinned,
-# this causes problems.
-cssselect = 0.9
-
-
-# Latest keyring releases 5.0, 5.1, 5.2 and 5.2.1 are not compatible, since they require a specific setuptools version.
-keyring = 4.1.1
-
-# Pin pyquery to 1.2.9, since the latest release 1.2.10 requires a newer version of cssselect, which is pinned to 0.7.1 by
-# http://download.zope.org/zopetoolkit/index/1.0.8/ztk-versions.cfg. pyquery 1.2.10 requires at least cssselect 0.7.9.
-pyquery = 1.2.9


### PR DESCRIPTION
The version pinnings generally asumes that Plone may override the pinnings by KGS. But that's actually not happening because we usually list test-base.cfg (via test-package.cfg) _after_ the KGS.

The Plone 5.1 tests are no longer working because of the zope.security pinning, which downgrades to an incompatible version.

Since those pinnings are generally quite old, I clean them up now.