### PR TITLE
Add default ignores to pyflakes package runs

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -255,11 +255,34 @@ entry-points = pyflakes=pyflakes.scripts.pyflakes:main
 initialization =
     import os
     import subprocess
+
     os.chdir("${buildout:directory}")
-    pkgdir = subprocess.Popen(
-        '${buildout:directory}/bin/package-directory relative',
-        shell=True, stdout=subprocess.PIPE).stdout.read().strip()
-    if len(sys.argv) == 1: sys.argv.extend([pkgdir])
+
+    if len(sys.argv) == 1:
+        # We're running this for a package
+        pkgdir = subprocess.Popen(
+            '${buildout:directory}/bin/package-directory relative',
+            shell=True,
+            stdout=subprocess.PIPE,
+            ).stdout.read().strip()
+
+        # We filter by filetype, filename and add our ignores
+        files = subprocess.Popen(
+            (
+                "find {} "
+                "-type 'f' "
+                "-name '*.py' "
+                "! -name '__init__.py' "
+                "! -name 'bootstrap.py' "
+                "! -name 'pyxbgen.py' "
+                "! -path '*/bindings/*' "
+                "! -path '*/skins/*' "
+            ).format(pkgdir),
+            shell=True,
+            stdout=subprocess.PIPE).stdout.read().splitlines()
+
+        sys.argv.extend(files)
+
 
 
 


### PR DESCRIPTION
We most likely do not want to run pyflakes on `__init__.py` files.

As this is the only thing we'd configure for pyflakes, I find this monkey patch good enough.