### PR TITLE
Added Plone 4.3.15 support and update hotfixes.

### DIFF
--- a/hotfixes/4.3.12.cfg
+++ b/hotfixes/4.3.12.cfg
@@ -1,15 +1,9 @@
 [buildout]
 
 hotfix-eggs =
-    Products.PloneHotfix20160830
-    Products.PloneHotfix20161129
-    Products.PloneHotfix20170117
 
 
 [versions]
-Products.PloneHotfix20160830 = 1.3
-Products.PloneHotfix20161129 = 1.2
-Products.PloneHotfix20170117 = 1.0
 
 # Use latest ``six`` version in order to avoid version conflict
 # since ``setuptools`` requires the latest ``six`` version but

--- a/hotfixes/4.3.14.cfg
+++ b/hotfixes/4.3.14.cfg
@@ -1,15 +1,9 @@
 [buildout]
 
 hotfix-eggs =
-    Products.PloneHotfix20160830
-    Products.PloneHotfix20161129
-    Products.PloneHotfix20170117
 
 
 [versions]
-Products.PloneHotfix20160830 = 1.3
-Products.PloneHotfix20161129 = 1.2
-Products.PloneHotfix20170117 = 1.0
 
 # Use latest ``six`` version in order to avoid version conflict
 # since ``setuptools`` requires the latest ``six`` version but

--- a/hotfixes/4.3.15.cfg
+++ b/hotfixes/4.3.15.cfg
@@ -1,0 +1,12 @@
+[buildout]
+
+hotfix-eggs =
+
+
+[versions]
+
+
+# Use latest ``six`` version in order to avoid version conflict
+# since ``setuptools`` requires the latest ``six`` version but
+# older Plone KGS pin older ``six`` versions.
+six = 1.10.0

--- a/hotfixes/4.3.15.cfg
+++ b/hotfixes/4.3.15.cfg
@@ -5,7 +5,6 @@ hotfix-eggs =
 
 [versions]
 
-
 # Use latest ``six`` version in order to avoid version conflict
 # since ``setuptools`` requires the latest ``six`` version but
 # older Plone KGS pin older ``six`` versions.

--- a/hotfixes/5.0.7.cfg
+++ b/hotfixes/5.0.7.cfg
@@ -1,15 +1,9 @@
 [buildout]
 
 hotfix-eggs =
-    Products.PloneHotfix20160830
-    Products.PloneHotfix20161129
-    Products.PloneHotfix20170117
 
 
 [versions]
-Products.PloneHotfix20160830 = 1.3
-Products.PloneHotfix20161129 = 1.2
-Products.PloneHotfix20170117 = 1.0
 
 # Use latest ``six`` version in order to avoid version conflict
 # since ``setuptools`` requires the latest ``six`` version but

--- a/hotfixes/5.0.8.cfg
+++ b/hotfixes/5.0.8.cfg
@@ -1,15 +1,9 @@
 [buildout]
 
 hotfix-eggs =
-    Products.PloneHotfix20160830
-    Products.PloneHotfix20161129
-    Products.PloneHotfix20170117
 
 
 [versions]
-Products.PloneHotfix20160830 = 1.3
-Products.PloneHotfix20161129 = 1.2
-Products.PloneHotfix20170117 = 1.0
 
 # Use latest ``six`` version in order to avoid version conflict
 # since ``setuptools`` requires the latest ``six`` version but

--- a/test-plone-4.3.15.cfg
+++ b/test-plone-4.3.15.cfg
@@ -1,0 +1,13 @@
+[buildout]
+extends =
+    http://dist.plone.org/release/4.3.15/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+
+jenkins_python = $PYTHON27
+
+
+
+[test]
+eggs +=
+    Pillow


### PR DESCRIPTION
I just created a policy using `bobtemplates` with plone `4.3.15`. The buildout failed because it expects the files included in this pr.

There are no hotfixes jet. Plone `4.3.15` war released on the 3rd of july.