### PR TITLE
Increase maximum line length.

### DIFF
--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -8,3 +8,4 @@
 # E128 continuation line under-indented for visual indent
 # E301 expected 1 blank line, found 0: zope security declarations
 ignore = E121,E122,E123,E125,E126,E127,E128,E301
+max-line-length = 150


### PR DESCRIPTION
Set the maximum line length to 150 for convenience.
The maximum line length use to solve the historic problem of low resolution displays, but nowadays we have larger displays and resolutions.