### PR TITLE
Ignore D104 - Missing docstring in public package.

### DIFF
--- a/pydocstyle.cfg
+++ b/pydocstyle.cfg
@@ -1,7 +1,8 @@
 [pydocstyle]
 # D100 Missing docstring in public module
 # D102	Missing docstring in public method
-# D103	Missing docstring in public function
+# D103  Missing docstring in public function
+# D104	Missing docstring in public package
 # D105	Missing docstring in magic method
 # D200	One-line docstring should fit on one line with quotes
 # D203	1 blank line required before class docstring
@@ -11,5 +12,5 @@
 # D400	First line should end with a period
 # D401	First line should be in imperative mood
 # D404	First word of the docstring should not be This
-add-ignore = D100,D102,D103,D105,D200,D203,D205,D212,D213,D400,D401,D404
+add-ignore = D100,D102,D103,D104,D105,D200,D203,D205,D212,D213,D400,D401,D404
 match = (?!(test_|__init__)).*\.py


### PR DESCRIPTION
Our `__init__.py`s are mostly empty.

Example packages:
- every upgrade step
- tests
- Most browser, viewlets, portlets folders.
 