### PR TITLE
Sanitize pycodestyle

### DIFF
--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -9,3 +9,4 @@
 # E301 expected 1 blank line, found 0: zope security declarations
 ignore = E121,E122,E123,E125,E126,E127,E128,E301
 max-line-length = 150
+exclude = bootstrap.py,pyxbgen.py,bindings,skins,monkey,tests

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -211,15 +211,30 @@ commands =
 recipe = zc.recipe.egg:scripts
 eggs = pycodestyle
 initialization =
-    import os
-    import subprocess
-    os.chdir("${buildout:directory}")
-    pkgdir = subprocess.Popen(
-        '${buildout:directory}/bin/package-directory relative',
-        shell=True, stdout=subprocess.PIPE).stdout.read().strip()
-    if '--absolute' in sys.argv: pkgdir = os.path.abspath(pkgdir) ; sys.argv.remove('--absolute')
-    if len(sys.argv) < 2: sys.argv.extend([pkgdir])
+    from os import chdir
+    from subprocess import PIPE
+    from subprocess import Popen
+
+    chdir("${buildout:directory}")
+
     sys.argv.append('--config=${pycodestyle-cfg:cfgfile}')
+
+    absolute_paths = False
+    if '--absolute' in sys.argv:
+        absolute_paths = True
+        sys.argv.remove('--absolute')
+
+    if len(sys.argv) < 3:
+        pkgdir = Popen(
+            '${buildout:directory}/bin/package-directory relative',
+            shell=True,
+            stdout=PIPE,
+            ).stdout.read().strip()
+
+        if absolute_paths:
+            pkgdir = os.path.abspath(pkgdir)
+
+        sys.argv.append(pkgdir)
 
 # Downloads the default pydocstyle.cfg.
 [pydocstyle-cfg]

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -208,7 +208,7 @@ commands =
 
 # bin/pycodestyle : pycodestyle validation of the packages source.
 [pycodestyle]
-recipe = zc.recipe.egg
+recipe = zc.recipe.egg:scripts
 eggs = pycodestyle
 initialization =
     import os

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -219,6 +219,7 @@ initialization =
         shell=True, stdout=subprocess.PIPE).stdout.read().strip()
     if '--absolute' in sys.argv: pkgdir = os.path.abspath(pkgdir) ; sys.argv.remove('--absolute')
     if len(sys.argv) < 2: sys.argv.extend([pkgdir])
+    sys.argv.append('--config=${pycodestyle-cfg:cfgfile}')
 
 # Downloads the default pydocstyle.cfg.
 [pydocstyle-cfg]

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -236,6 +236,8 @@ initialization =
 
         sys.argv.append(pkgdir)
 
+
+
 # Downloads the default pydocstyle.cfg.
 [pydocstyle-cfg]
 recipe = collective.recipe.shelloutput

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -210,7 +210,6 @@ commands =
 [pycodestyle]
 recipe = zc.recipe.egg
 eggs = pycodestyle
-args = ['--exclude=tests', '--config=${pycodestyle-cfg:cfgfile}']
 initialization =
     import os
     import subprocess
@@ -220,7 +219,6 @@ initialization =
         shell=True, stdout=subprocess.PIPE).stdout.read().strip()
     if '--absolute' in sys.argv: pkgdir = os.path.abspath(pkgdir) ; sys.argv.remove('--absolute')
     if len(sys.argv) < 2: sys.argv.extend([pkgdir])
-    sys.argv.extend(${pycodestyle:args})
 
 # Downloads the default pydocstyle.cfg.
 [pydocstyle-cfg]


### PR DESCRIPTION
Once we started using these out on the field, some of my assumptions have proven mistaken and I'm beginning a cleanup round.

* The file exlusion mechanism will be moved to the `.cfg` file
  * Tests are no longer excluded for `pycodestyle` per default
  * Projects can still override the `[-cfg]` part
* The config file is always appended in Python
* The package directory is only discovered if no arguments are provided by the user