### PR TITLE
Production v2: grant other deployers to change bin scripts.

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -31,4 +31,6 @@ command =
     chmod --silent u-x ${buildout:directory}/bin/supervisord
     # Make sure that other users can access the egg infos later.
     chmod -R --silent g+rw,o+r /apps/eggs/*
+    # Make sure other deployers can change bin scripts.
+    chmod --silent g+rw ${buildout:directory}/bin/*
 update-command = ${:command}


### PR DESCRIPTION
Other deployers should be able to update bin/* scripts when running buildout.
In order for that to work, the `deploy`-group must have `+rw` on `bin/*`.