### PR TITLE
Pypi is now HTTPS only.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -780,10 +780,10 @@ Options:
 
 
 
-.. _coverage: http://pypi.python.org/pypi/coverage
+.. _coverage: https://pypi.python.org/pypi/coverage
 .. _Cobertura Jenkins Plugin: https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin
 .. _Warnings Plugin: https://wiki.jenkins-ci.org/display/JENKINS/Warnings+Plugin
-.. _omelette: http://pypi.python.org/pypi/collective.recipe.omelette
+.. _omelette: https://pypi.python.org/pypi/collective.recipe.omelette
 .. _PhantomJS: http://phantomjs.org/
 .. _ftw.recipe.deployment: https://github.com/4teamwork/ftw.recipe.deployment
 .. _ftw.inflator: https://github.com/4teamwork/ftw.inflator

--- a/hotfixes/update.py
+++ b/hotfixes/update.py
@@ -65,7 +65,7 @@ def get_hotfix_version(package):
     if package in HOTFIX_VERSIONS:
         return HOTFIX_VERSIONS[package]
 
-    url = 'http://pypi.python.org/pypi/{}/json'.format(package)
+    url = 'https://pypi.python.org/pypi/{}/json'.format(package)
     pkg_info = json.loads(http_get(url))
     HOTFIX_VERSIONS[package] = pkg_info['info']['version']
     return HOTFIX_VERSIONS[package]

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -69,10 +69,8 @@ develop = .
 results-dir = ${buildout:directory}/parts/testresults
 
 
-find-links = http://pypi.python.org/
-#find-links = http://pypi.4teamwork.ch/
-index = http://pypi.python.org/simple/
-#index = http://pypi.4teamwork.ch/simple/
+find-links = https://pypi.python.org/
+index = https://pypi.python.org/simple/
 versions = versions
 
 # Show the picked version in the buildout log.


### PR DESCRIPTION
- pypi must now be accessed with https, http is no longer supported. [1]
- Accessing pypi with http results in an "403 Forbidden", which is actually wrong and leads to plugins, such as isotoma.buildout.http, trying to authenticate.

[1] https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html