### PR TITLE
Configure a crawler_site_id by default.

### DIFF
--- a/solr-base.cfg
+++ b/solr-base.cfg
@@ -12,6 +12,10 @@ parts =
     solr-download
     solr-instance
 
+# Increment this value, if you change solr related configs in this file.
+# This makes the solr recipe detect a change and perform a reinstall.
+config-version = 2
+
 
 [solr-settings]
 # port =
@@ -49,6 +53,9 @@ host = ${solr-settings:host}
 port = ${solr-settings:port}
 basepath = ${solr-settings:base}
 solr-version = ${solr-settings:solr-major-version}
+# The config version is not used by the recipe but its purpose is to change
+# the config of this buildout part so that it gets reinstalled when incremented.
+config-version = ${solr:config-version}
 
 java_opts =
   -server
@@ -215,3 +222,4 @@ index =
     name:Title                  type:text stored:true
     name:Type                   type:string stored:true
     name:UID                    type:string stored:true required:true
+    name:crawler_site_id        type:string stored:true required:true


### PR DESCRIPTION
ftw.crawler now supports to configure a crawler_site_id. This change adds such a field for all solr cores by default. See https://github.com/4teamwork/ftw.crawler/pull/9

By adding the `crawler_site_id` field to the core template, all solr installation based on this buildout config will automatically receive the field for all cores, making it easier for developers to adapt to this feature.
It isn't necessary to have the field on regulare cores, but it is easier to add it to all cores in ftw-buildouts than to add the field in each project separately.

**config-version**:
The `collective.recipe.solrinstance` does not properly update the configuration: it only reinstalls when values of its part change. When configurations of the cores change, those changes are not in the solrinstance part and thus the recipe does not reinstall and the change is not applied.
As workaround we introduce a `config-version` value which is simply incremented and will trigger a reinstall of the solr part whenever incremented.