### PR TITLE
Add W503 to pycodestyle ignores

### DIFF
--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -7,6 +7,7 @@
 # E127 continuation line over-indented for visual indent
 # E128 continuation line under-indented for visual indent
 # E301 expected 1 blank line, found 0: zope security declarations
-ignore = E121,E122,E123,E125,E126,E127,E128,E301
+# W503 line break occurred before a binary operator - ref. https://github.com/PyCQA/pycodestyle/issues/498
+ignore = E121,E122,E123,E125,E126,E127,E128,E301,W503
 max-line-length = 150
 exclude = bootstrap.py,pyxbgen.py,bindings,skins,monkey,tests


### PR DESCRIPTION
Ref. https://github.com/PyCQA/pycodestyle/issues/498 - PEP-8 itself bent for readability.

This is also in the default overrides of pycodestyle since 2.0.0:
https://github.com/PyCQA/pycodestyle/blob/c631809438660583b7b7f061d9858ff9e9ad27e4/CHANGES.txt#L82