### PR TITLE
Let only instance0 eager-load chameleon templates by default.

### DIFF
--- a/chameleon.cfg
+++ b/chameleon.cfg
@@ -2,7 +2,6 @@
 instance-eggs += ftw.chameleon
 parts += chameleon-cache
 environment-vars +=
-    CHAMELEON_EAGER ${buildout:chameleon-eager}
     CHAMELEON_RELOAD ${buildout:chameleon-reload}
     CHAMELEON_CACHE ${buildout:chameleon-cache}
     FTW_CHAMELEON_RECOOK_WARNING ${buildout:chameleon-recook-warning}

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -35,7 +35,7 @@ hotfix-eggs =
 environment-vars =
     zope_i18n_compile_mo_files true
 
-chameleon-eager = true
+chameleon-eager-development = true
 chameleon-reload = true
 chameleon-cache = ${buildout:directory}/var/chameleon-cache
 chameleon-recook-warning = true
@@ -56,6 +56,8 @@ eggs =
     ${buildout:hotfix-eggs}
     plone.reload
     collective.z3cinspector
+environment-vars +=
+    CHAMELEON_EAGER ${buildout:chameleon-eager-development}
 
 environment-vars = ${buildout:environment-vars}
 zcml-additional =

--- a/production.cfg
+++ b/production.cfg
@@ -52,7 +52,11 @@ supervisor-haproxy-backend = plone${buildout:deployment-number}
 supervisor-haproxy-socket = tcp://localhost:8801
 supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/${buildout:supervisor-haproxy-backend}01
 
-chameleon-eager = true
+# Eager: by default, we want instance0 to do eager loading, and let all other not
+# do eager loading. Therefore we distinct between chameleon-eager-default and
+# chameleon-eager-instance0.
+chameleon-eager-default = false
+chameleon-eager-instance0 = true
 chameleon-reload = false
 chameleon-cache = ${buildout:directory}/var/chameleon-cache
 chameleon-recook-warning = true
@@ -106,13 +110,15 @@ zcml-additional =
     <configure xmlns="http://namespaces.zope.org/zope">
         ${buildout:zcml-additional-fragments}
     </configure>
-
+chameleon-eager = ${buildout:chameleon-eager-instance0}
 
 zope-conf-additional =
     datetime-format international
     trusted-proxy 127.0.0.1
 
-environment-vars = ${buildout:environment-vars}
+environment-vars =
+    ${buildout:environment-vars}
+    CHAMELEON_EAGER ${:chameleon-eager}
 initialization =
     # Import _strptime before starting any threads to avoid race condition.
     # See http://bugs.python.org/issue7980
@@ -123,6 +129,7 @@ initialization =
 [instance1]
 <= instance0
 http-address = 1${buildout:deployment-number}01
+chameleon-eager = ${buildout:chameleon-eager-default}
 
 
 

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -8,6 +8,7 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 [instance2]
 <= instance0
 http-address = 1${buildout:deployment-number}02
+chameleon-eager = ${buildout:chameleon-eager-default}
 
 
 [supervisor]

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -9,11 +9,13 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 [instance2]
 <= instance0
 http-address = 1${buildout:deployment-number}02
+chameleon-eager = ${buildout:chameleon-eager-default}
 
 
 [instance3]
 <= instance0
 http-address = 1${buildout:deployment-number}03
+chameleon-eager = ${buildout:chameleon-eager-default}
 
 
 [supervisor]

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -10,16 +10,19 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 [instance2]
 <= instance0
 http-address = 1${buildout:deployment-number}02
+chameleon-eager = ${buildout:chameleon-eager-default}
 
 
 [instance3]
 <= instance0
 http-address = 1${buildout:deployment-number}03
+chameleon-eager = ${buildout:chameleon-eager-default}
 
 
 [instance4]
 <= instance0
 http-address = 1${buildout:deployment-number}04
+chameleon-eager = ${buildout:chameleon-eager-default}
 
 
 [supervisor]

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -36,6 +36,7 @@ zope-conf-additional =
         user ${buildout:publisher-sender-username}
         password ${buildout:publisher-sender-password}
     </clock-server>
+chameleon-eager = false
 
 
 [supervisor]

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -6,6 +6,7 @@ parts +=
 [instancepub]
 <= instance0
 http-address = 1${buildout:deployment-number}10
+chameleon-eager = false
 
 
 


### PR DESCRIPTION
We've realized that it is probably a bad idea to let all instances eager-load (=precompile) chameleon templates. It can get messy and lead to errors when multiple instances are precompiling at the same time. (see https://community.plone.org/t/chameleon-typeerror-dict-object-is-not-callable/5391)

In order to only precompile on instance0 by default, the `chameleon-eager` configuration option for production is split into a `chameleon-eager-default` option (used for instances 1-4) and a `chameleon-eager-instance0` option (used for instance0 only). For publisher instances we disable eager loading because they never render things.

Since all instance parts copy from `instance0`, the option must be configured in each instance part with another option.

Effects of this change:
- In a default production environment, `instance0` will be the only instance which is eager-loading the templates.
- The `buildout:chameleon-eager` option is no longer available.
- The `CHAMELEON_EAGER` environment variable also set even when `chameleon.cfg` is not extended.