### PR TITLE
Use distinct chameleon cache directories per instance.

### DIFF
--- a/chameleon.cfg
+++ b/chameleon.cfg
@@ -4,15 +4,22 @@ parts += chameleon-cache
 environment-vars +=
     CHAMELEON_EAGER ${buildout:chameleon-eager}
     CHAMELEON_RELOAD ${buildout:chameleon-reload}
-    CHAMELEON_CACHE ${buildout:chameleon-cache}
     FTW_CHAMELEON_RECOOK_WARNING ${buildout:chameleon-recook-warning}
     FTW_CHAMELEON_RECOOK_EXCEPTION ${buildout:chameleon-recook-exception}
 
 
 [chameleon-cache]
 recipe = collective.recipe.shelloutput
-commands =
-    cmd1 = mkdir -p ${buildout:chameleon-cache}
+
+
+[instance]
+environment-vars +=
+    CHAMELEON_CACHE ${:chameleon-cache}
+
+
+[instance0]
+environment-vars +=
+    CHAMELEON_CACHE ${:chameleon-cache}
 
 
 [test]

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -49,6 +49,7 @@ http-address = 8080
 debug-mode = on
 verbose-security = on
 blob-storage = var/blobstorage
+chameleon-cache = ${buildout:directory}/var/${:_buildout_section_name_}/chameleon-cache
 eggs =
     Plone
     ${buildout:package-name}
@@ -67,6 +68,11 @@ initialization =
     # Import _strptime before starting any threads to avoid race condition.
     # See http://bugs.python.org/issue7980
     import _strptime
+
+
+[chameleon-cache]
+commands =
+    cmd = mkdir -p ${instance:chameleon-cache}
 
 
 [omelette]

--- a/production.cfg
+++ b/production.cfg
@@ -54,7 +54,6 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 
 chameleon-eager = true
 chameleon-reload = false
-chameleon-cache = ${buildout:directory}/var/chameleon-cache
 chameleon-recook-warning = true
 chameleon-recook-exception = false
 
@@ -97,6 +96,7 @@ zeo-client = on
 zeo-address = ${zeo:zeo-address}
 shared-blob = on
 user = zopemaster:admin
+chameleon-cache = ${buildout:directory}/var/${:_buildout_section_name_}/chameleon-cache
 http-address = 1${buildout:deployment-number}00
 eggs =
     Plone
@@ -123,6 +123,13 @@ initialization =
 [instance1]
 <= instance0
 http-address = 1${buildout:deployment-number}01
+
+
+
+[chameleon-cache]
+commands =
+    cmd = mkdir -p ${instance0:chameleon-cache}
+    cmd = mkdir -p ${instance1:chameleon-cache}
 
 
 

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -17,3 +17,8 @@ programs +=
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
     ${supervisor:eventlistener-httpok2}
+
+
+[chameleon-cache]
+commands +=
+    cmd = mkdir -p ${instance2:chameleon-cache}

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -26,3 +26,9 @@ eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p ins
 eventlisteners +=
     ${supervisor:eventlistener-httpok2}
     ${supervisor:eventlistener-httpok3}
+
+
+[chameleon-cache]
+commands +=
+    cmd = mkdir -p ${instance2:chameleon-cache}
+    cmd = mkdir -p ${instance3:chameleon-cache}

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -35,3 +35,10 @@ eventlisteners +=
     ${supervisor:eventlistener-httpok2}
     ${supervisor:eventlistener-httpok3}
     ${supervisor:eventlistener-httpok4}
+
+
+[chameleon-cache]
+commands +=
+    cmd = mkdir -p ${instance2:chameleon-cache}
+    cmd = mkdir -p ${instance3:chameleon-cache}
+    cmd = mkdir -p ${instance4:chameleon-cache}

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -45,3 +45,9 @@ programs +=
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
     ${supervisor:eventlistener-httpokpub}
+
+
+
+[chameleon-cache]
+commands +=
+    cmd = mkdir -p ${instancepub:chameleon-cache}

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -16,3 +16,9 @@ programs +=
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners +=
     ${supervisor:eventlistener-httpokpub}
+
+
+
+[chameleon-cache]
+commands +=
+    cmd = mkdir -p ${instancepub:chameleon-cache}


### PR DESCRIPTION
We've had chameleon compilation errors which may have been caused by using a shared chameleon cache. (see https://community.plone.org/t/chameleon-typeerror-dict-object-is-not-callable/5391)

Therefore we're changing buildout to configure a separate chameleon cache directory for each instance.

The directories must exist and are not created by Chameleon. For easier understanding and handling we just create directories for all instances we now in ftw-buildouts, no metter whether they are actually used or not.

Replaces #109