### PR TITLE
Fix chameleon cache location for local Plone development.

### DIFF
--- a/chameleon.cfg
+++ b/chameleon.cfg
@@ -26,4 +26,4 @@ environment-vars +=
 eggs += ftw.chameleon
 initialization +=
     import os
-    if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = '${buildout:chameleon-cache}'
+    if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = '${instance:chameleon-cache}'

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -37,7 +37,6 @@ environment-vars =
 
 chameleon-eager = true
 chameleon-reload = true
-chameleon-cache = ${buildout:directory}/var/chameleon-cache
 chameleon-recook-warning = true
 chameleon-recook-exception = false
 


### PR DESCRIPTION
The initialization script for `bin/test` contained a left over reference to `${buildout:chameleon-cache}`. This is not where the chameleon cache directory is configured any more, we manage it per instance instead after #110.

I therefore changed the `bin/test` template to directly refer to `${instance:chameleon-cache}` and dropped the `${buildout:chameleon-cache}` from `plone-development.cfg` alltogether (shouldn't be used anywhere any more).