### PR TITLE
Improve output of xml tests when tests fail

### DIFF
--- a/test-xmls-formatted.cfg
+++ b/test-xmls-formatted.cfg
@@ -18,7 +18,7 @@ output = ${buildout:bin-directory}/test-jenkins
 mode = 755
 input = inline:
     #!/bin/bash
-    set -euo pipefail
+    set -uo pipefail
 
     BUILD_LOG="format_all_xmls.log"
 
@@ -26,5 +26,8 @@ input = inline:
     result=$?
     if [[ $result == 0 ]]; then
        echo "All XMLs formatted correctly."
+    else
+       echo "Please run bin/format-all-xmls on your machine and commit the changes."
     fi
+
     exit $result


### PR DESCRIPTION
This is helpful for new users that dont know about the `format-all-xmls` script yet. This way they know how to fix the xml indendation error.