### PR TITLE
Pin "collective.z3cform.colorpicker".

### DIFF
--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -29,3 +29,6 @@ six = 1.4.1
 
 # Pillow 4.2.0 is not compatible with the Plone image scaling.
 Pillow = 4.1.1
+
+# collective.z3cform.colorpicker >= 2.0 requires Plone 5.
+collective.z3cform.colorpicker = 1.4

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -18,3 +18,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# collective.z3cform.colorpicker >= 2.0 requires Plone 5.
+collective.z3cform.colorpicker = 1.4


### PR DESCRIPTION
collective.z3cform.colorpicker >= 2.0 requires Plone 5 which causes an error during buildout.