### PR TITLE
Fix missing permissions for Production-V2 buildout

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -31,6 +31,8 @@ command =
     chmod --silent u-x ${buildout:directory}/bin/supervisord
     # Make sure that other users can access the egg infos later.
     chmod -R --silent g+rw,o+r /apps/eggs/*
+    # Make sure that other users can access the extends-cache later.
+    chmod -R --silent g+rw,o+r /apps/extends-cache/*
     # Make sure other deployers can change bin scripts.
     chmod --silent g+rw ${buildout:directory}/bin/*
     # Make sure that "zope" have write access to solr-specific folders.

--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -33,4 +33,7 @@ command =
     chmod -R --silent g+rw,o+r /apps/eggs/*
     # Make sure other deployers can change bin scripts.
     chmod --silent g+rw ${buildout:directory}/bin/*
+    # Make sure that "zope" have write access to solr-specific folders.
+    chgrp --silent -R zope ${buildout:directory}/parts/solr-instance/logs
+    chgrp --silent -R zope ${buildout:directory}/parts/solr-instance/solr-webapp
 update-command = ${:command}


### PR DESCRIPTION
This PR fixes two missing permissions within the new production-v2 buildout:

1.  Add rw permission for the `deploy`-group for the `extends-cache` folder
2. Change the owner of the `solr`-specific folders to `zope`. This is required to run solr properly.


⚠️ The solr-specific adjustments would belong to a `solr-v2.cfg` which does not exists yet. But including it in the production-v2.cfg makes it easier to read and adjust because all v2-adjustments are within one file. Due to the `--slient` parameter, the script does not fail if the folders do not exist. Is this OK? Or do you prefer a new cfg for the solr-specific adjustments (`solr-v2.cfg`)?