### PR TITLE
Add another chmod to production-v2.cfg

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -35,6 +35,8 @@ command =
     chmod -R --silent g+rw,o+r /apps/extends-cache/*
     # Make sure other deployers can change bin scripts.
     chmod --silent g+rw ${buildout:directory}/bin/*
+    # Make sure other deployers can change parts.
+    chmod -R --silent g+rw ${buildout:directory}/parts/instance?/*
     # Make sure that "zope" have write access to solr-specific folders.
     chgrp --silent -R zope ${buildout:directory}/parts/solr-instance/logs
     chgrp --silent -R zope ${buildout:directory}/parts/solr-instance/solr-webapp


### PR DESCRIPTION
Deployers can now modify in parts instance
${buildout:directory}/parts/instance?/