### PR TITLE
solr-v2: Set stopasgroup=true in solr supervisor config in order

### DIFF
--- a/solr-v2.cfg
+++ b/solr-v2.cfg
@@ -18,5 +18,5 @@ cores = ${buildout:solr-core-name}
 
 [supervisor]
 programs +=
-    10 solr (startsecs=5) ${buildout:bin-directory}/solr [console] true ${buildout:os-user}
+    10 solr (startsecs=5 stopasgroup=true) ${buildout:bin-directory}/solr [console] true ${buildout:os-user}
 


### PR DESCRIPTION
solr-v2: Set `stopasgroup=true` in solr supervisor config in order to make sure not just the wrapper script is killed, but the signal gets sent to the entire process group and also reaches the Solr
process.