### PR TITLE
Ignore solrconfig.xml from XML formatting checks.

### DIFF
--- a/format-xml.cfg
+++ b/format-xml.cfg
@@ -41,5 +41,5 @@ input = inline:
     IFS=$'\n'
     pkgdir=$(${buildout:bin-directory}/package-directory)
     formatter="${buildout:bin-directory}/format-xml"
-    $formatter $(find $pkgdir \! -path "*/upgrades/*" -type f \( -iname \*.xml -o -iname \*.zcml \) ! -name definition.xml) "$@"
+    $formatter $(find $pkgdir \! -path "*/upgrades/*" -type f \( -iname \*.xml -o -iname \*.zcml \) ! -name definition.xml ! -name solrconfig.xml) "$@"
     exit $?


### PR DESCRIPTION
Ignore `solrconfig.xml` from XML formatting checks.