### PR TITLE
Ensure chameleon cache directory variable for all tests.

### DIFF
--- a/chameleon.cfg
+++ b/chameleon.cfg
@@ -24,6 +24,3 @@ environment-vars +=
 
 [test]
 eggs += ftw.chameleon
-initialization +=
-    import os
-    if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = '${instance:chameleon-cache}'

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -105,6 +105,10 @@ initialization =
     except OSError: pass
     os.chdir(test_directory)
     os.environ['zope_i18n_compile_mo_files'] = 'true'
+    chameleon_cache_dir = '${buildout:directory}/parts/test/chameleon-cache'
+    try: os.makedirs(chameleon_cache_dir)
+    except OSError: pass
+    if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = chameleon_cache_dir
 scripts = test
 
 # collective.xmltestreport currently returns bad exit codes when installed as it


### PR DESCRIPTION
The chameleon.cfg is usually not extended by test buildout configs, thus it does not ensure the CHAMELEON_CACHE environment variable on the CI server.

The CI server used to set the directory to one globally shared directory, which is a bad idea because of concurrency issues.

Therefore we now always provide a chameleon cache directory, if not yet set, so that each test has an own chameleon cache directory and we have no concurrency issues.

In a local development environment, where we install `development.cfg` and include `chameleon.cfg`, the tests have now their own cache directory.