### PR TITLE
Use the buildout os-user variable instead of hard-coding the zope user

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -25,7 +25,7 @@ etc-directory = /apps/etc
 # let the service user "zope" have write access.
 recipe = plone.recipe.command
 command =
-    chgrp --silent -R zope ${buildout:directory}/var
+    chgrp --silent -R ${buildout:os-user} ${buildout:directory}/var
     find ${buildout:directory}/var -maxdepth 1 -type d -exec chmod --silent 2770 {} \;
     # Make sure supervisord is always started as "zope" user using sudo.
     chmod --silent u-x ${buildout:directory}/bin/supervisord
@@ -42,6 +42,6 @@ command =
     chmod -R --silent g+rw ${buildout:directory}/parts/*
     chgrp -R --silent deploy ${buildout:directory}/parts/*
     # Make sure that "zope" have write access to solr-specific folders.
-    chgrp --silent -R zope ${buildout:directory}/parts/solr-instance/logs
-    chgrp --silent -R zope ${buildout:directory}/parts/solr-instance/solr-webapp
+    chgrp --silent -R ${buildout:os-user} ${buildout:directory}/parts/solr-instance/logs
+    chgrp --silent -R ${buildout:os-user} ${buildout:directory}/parts/solr-instance/solr-webapp
 update-command = ${:command}


### PR DESCRIPTION
I'm currently setting up a production style deployment and trying to use a new style deployment. This hardcodes the user, which is a problem for me.

Is there currently anything out there which will get broken by this? The readme does tell one to set `os-user`.