### PR TITLE
Remove group execute rights

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -28,7 +28,7 @@ command =
     chgrp --silent -R zope ${buildout:directory}/var
     find ${buildout:directory}/var -maxdepth 1 -type d -exec chmod --silent 2770 {} \;
     # Make sure supervisord is always started as "zope" user using sudo.
-    chmod --silent u-x ${buildout:directory}/bin/supervisord
+    chmod --silent u-x,g-x ${buildout:directory}/bin/supervisord
     # Make sure that other users can access the egg infos later.
     chmod -R --silent g+rw,o+r /apps/eggs/*
     # Make sure that other users can access the extends-cache later.


### PR DESCRIPTION
Don't allow to execute supervisord for developers:
> -rw-rw-r-x  bin/supervisord