### PR TITLE
Fix solr index: crawler_site_id is no longer required

### DIFF
--- a/solr-base.cfg
+++ b/solr-base.cfg
@@ -14,7 +14,7 @@ parts =
 
 # Increment this value, if you change solr related configs in this file.
 # This makes the solr recipe detect a change and perform a reinstall.
-config-version = 2
+config-version = 3
 
 
 [solr-settings]
@@ -222,4 +222,4 @@ index =
     name:Title                  type:text stored:true
     name:Type                   type:string stored:true
     name:UID                    type:string stored:true required:true
-    name:crawler_site_id        type:string stored:true required:true
+    name:crawler_site_id        type:string stored:true


### PR DESCRIPTION
This PR fixes the `crawler_site_id` index implemented in https://github.com/4teamwork/ftw-buildouts/pull/106/files

Indexing solr with required solr-indexes which are not available in Plone will skip the indexing item.

The `crawler_site_id` is not a default plone indexer but it's required. Indexing with this config without a `crawler_site_id` will skip every object.

Mark as missing:
https://github.com/collective/collective.solr/blob/master/src/collective/solr/indexer.py#L382

Skip:
https://github.com/collective/collective.solr/blob/master/src/collective/solr/indexer.py#L227
 
This PR just mark the `crawler_site_id` index as optional.