### PR TITLE
Workaround for version constraint error when testing against Plone 4.2.

### DIFF
--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -32,3 +32,6 @@ Pillow = 4.1.1
 
 # collective.z3cform.colorpicker >= 2.0 requires Plone 5.
 collective.z3cform.colorpicker = 1.4
+
+# Workaround for version constraint error (i18ndude >= 5.0 requires zope.tal >= 4.3.0).
+i18ndude=4.4.0


### PR DESCRIPTION
The latest i18ndude >= 5.0 requires zope.tal >= 4.3.0, so we need to use an older release fo i18ndude.