### PR TITLE
Update allow-hosts to make redirects to  pypi.org work:

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -28,6 +28,8 @@ index = https://pypi.python.org/simple/
 allow-hosts =
     pypi.python.org
     *.pypi.python.org
+    pypi.org
+    files.pythonhosted.org
     *.4teamwork.ch
     effbot.org
     code.google.com

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -79,6 +79,8 @@ show-picked-versions = true
 allow-hosts =
     pypi.python.org
     *.pypi.python.org
+    pypi.org
+    files.pythonhosted.org
     *.4teamwork.ch
     effbot.org
     code.google.com

--- a/tika-jaxrs-standalone.cfg
+++ b/tika-jaxrs-standalone.cfg
@@ -22,6 +22,8 @@ versions = versions
 allow-hosts =
     pypi.python.org
     *.pypi.python.org
+    pypi.org
+    files.pythonhosted.org
     *.4teamwork.ch
     effbot.org
     code.google.com


### PR DESCRIPTION
`pypi.python.org` started redirecting a fraction of its traffic to `pypi.org` in preparation for the final rollout of the new codebase.

This means, in order for downloads to be allowed from the new location, both `pypi.org` (the package index) and `files.pythonhosted.org` (where the actual packages are hosted) need to be whitelisted in `allow-hosts`.

---

Notice as seen on https://status.python.org/

![pypi_redirect](https://user-images.githubusercontent.com/405124/38694185-4209969e-3e89-11e8-9fa7-7eac524bcbcb.png)

FYI: The messages about blocked hosts get swallowed by this lovely piece of code in `zc.buildout.easy_install`:

```python
        # distutils has its own logging, which can't be hooked / suppressed,
        # so we monkey-patch the 'log' submodule to suppress the stupid
        # "Link to <URL> ***BLOCKED*** by --allow-hosts" message.
        with _Monkey(setuptools.package_index, log=_no_warn):
            return setuptools.package_index.PackageIndex.url_ok(
                                                self, url, False)
```

https://github.com/buildout/buildout/blob/f75d0e7a336b8912f68633508d9bf0d8be80b747/src/zc/buildout/easy_install.py#L124-L129
