### PR TITLE
Ignore pycodestyle W606

### DIFF
--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -8,6 +8,7 @@
 # E128 continuation line under-indented for visual indent
 # E301 expected 1 blank line, found 0: zope security declarations
 # W503 line break occurred before a binary operator - ref. https://github.com/PyCQA/pycodestyle/issues/498
-ignore = E121,E122,E123,E125,E126,E127,E128,E301,W503
+# W606 'async' and 'await' are reserved keywords starting with Python 3.7
+ignore = E121,E122,E123,E125,E126,E127,E128,E301,W503,W606
 max-line-length = 150
 exclude = bootstrap.py,pyxbgen.py,bindings,skins,monkey,tests


### PR DESCRIPTION
It's not reasonable for us to fix all occurences of this anytime soon.

An example of a trip-up:
`form.widget('secretary', KeywordFieldWidget, async=True)`
https://ci.4teamwork.ch/builds/157939/tasks/249497