### PR TITLE
pycodestyle: Exclude 'docs' directory from QA checks.

### DIFF
--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -11,4 +11,4 @@
 # W606 'async' and 'await' are reserved keywords starting with Python 3.7
 ignore = E121,E122,E123,E125,E126,E127,E128,E301,W503,W606
 max-line-length = 150
-exclude = bootstrap.py,pyxbgen.py,bindings,skins,monkey,tests
+exclude = bootstrap.py,pyxbgen.py,bindings,skins,monkey,tests,docs


### PR DESCRIPTION
Exclude `docs` directory from pycodestyle QA checks.

(Because extending it just for `opengever.core` like this [didn't work](https://ci.4teamwork.ch/builds/175265/tasks/282778)):

```ini
[pycodestyle-cfg]
# Prepend additional excludes ('docs' folder) after the base cfg has been built
commands +=
  cmd3 = sed -i.bak 's/^exclude = /exclude = docs,/g' ${:cfgfile}
```