### PR TITLE
Decrease max-line-length from 150 to 125.

### DIFF
--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -10,5 +10,5 @@
 # W503 line break occurred before a binary operator - ref. https://github.com/PyCQA/pycodestyle/issues/498
 # W606 'async' and 'await' are reserved keywords starting with Python 3.7
 ignore = E121,E122,E123,E125,E126,E127,E128,E301,W503,W606
-max-line-length = 150
+max-line-length = 125
 exclude = bootstrap.py,pyxbgen.py,bindings,skins,monkey,tests,docs


### PR DESCRIPTION
According to the devdocs we have a hard-limit of 125 characters.
See https://github.com/4teamwork/devdocs.4teamwork.ch/pull/43 for the discussion and the backgrounds.