### PR TITLE
Introduce instance-zcml and instance-early-zcml options. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,8 @@ Details:
   It defaults to ``zope``.
 - ``plone-languages`` - The short names of the languages which are loaded by Zope.
 - ``zcml-additional-fragments`` - Define additional zcml to load. See the `Additional ZCML`_ section.
+- ``instance-zcml`` - Add packages to the instances `zcml` list.
+- ``instance-early-zcml`` - Add packages on top of the instances `zcml` list.
 
 
 HAProxy / Supervisor integration

--- a/plone-development.cfg
+++ b/plone-development.cfg
@@ -30,6 +30,8 @@ dump-picked-versions = true
 show-picked-versions = true
 
 zcml-additional-fragments =
+instance-early-zcml =
+instance-zcml =
 instance-eggs =
 hotfix-eggs =
 environment-vars =
@@ -62,6 +64,10 @@ zcml-additional =
     <configure xmlns="http://namespaces.zope.org/zope">
         ${buildout:zcml-additional-fragments}
     </configure>
+
+zcml =
+    ${buildout:instance-early-zcml}
+    ${buildout:instance-zcml}
 
 initialization =
     # Import _strptime before starting any threads to avoid race condition.

--- a/production.cfg
+++ b/production.cfg
@@ -65,6 +65,8 @@ os-user = zope
 plone-languages = en de fr it
 
 zcml-additional-fragments =
+instance-early-zcml =
+instance-zcml =
 environment-vars =
     PTS_LANGUAGES ${buildout:plone-languages}
     zope_i18n_allowed_languages ${buildout:plone-languages}
@@ -109,6 +111,9 @@ zcml-additional =
         ${buildout:zcml-additional-fragments}
     </configure>
 
+zcml =
+    ${buildout:instance-early-zcml}
+    ${buildout:instance-zcml}
 
 zope-conf-additional =
     datetime-format international


### PR DESCRIPTION
This provides the possibility to add packages to the instances `zcml` list (early means on top). This can be useful to make sure that translation overrides works as expected.