### PR TITLE
Use the newest version of setuptools.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -11,11 +11,6 @@ selenium =
 splinter = 0.6.0
 
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
-zc.buildout= >2
-distribute=
-
-# setuptools 34.0.0 unvendors six (#933) and adds a version constraint which is
-# incompatible Plone KGS.
-# Additionally, setuptools 34.0.2 seems to cause issues with older versions
-# of pip (#945)
-setuptools = 33.1.1
+zc.buildout = >2
+setuptools =
+distribute =


### PR DESCRIPTION
The current combination if an old setuptools, the new zc.buildout and a virtualenv which may also contain a setuptools leads to self-update-loops.

It seems that the newest setuptools / zc.buildout combination works well again and we can update.

@lukasgraf can you confirm that the problems leading to pinning down setuptools no longer occur with never versions? I caught me pinning up setuptools multiple times in order to solve auto-update-loops and I think it is time to update to the newest version 😎 