### PR TITLE
Prefer final releases in testing.

### DIFF
--- a/test-package.cfg
+++ b/test-package.cfg
@@ -13,7 +13,6 @@ always-checkout = force
 always-accept-server-certificate = true
 
 newest = true
-prefer-final = false
 
 
 # bin/test-jenkins : A script running the tests with coverage and running


### PR DESCRIPTION
Pre-releases of any dependencies may be submitted to pypi. Those releases may be broken and not installable. If we are not pinning anything, the "prefer-final=false" setting will install those broken releases, making our tests fail. We should not test against non-final third-party releases. If we really want to test against a non-final version we can still pin in in the versions.cfg.

Currently solving:
```python
Getting distribution for 'openpyxl'.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/command/easy_install.py", line 2270, in main
  File "/usr/local/python/2.7.14/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/local/python/2.7.14/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/local/python/2.7.14/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/command/easy_install.py", line 411, in run
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/command/easy_install.py", line 655, in easy_install
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/command/easy_install.py", line 700, in install_item
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/command/easy_install.py", line 881, in install_eggs
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/command/easy_install.py", line 1120, in build_and_install
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/command/easy_install.py", line 1106, in run_setup
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 258, in run_setup
  File "/usr/local/python/2.7.14/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 198, in setup_context
  File "/usr/local/python/2.7.14/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 169, in save_modules
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 144, in resume
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 157, in save_modules
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 198, in setup_context
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 255, in run_setup
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 285, in run
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 253, in runner
  File "/var/lib/jenkins/zope/eggs/setuptools-33.1.1-py2.7.egg/setuptools/sandbox.py", line 47, in _execfile
  File "/tmp/easy_install-CLiesR/openpyxl-3.0.0.dev0/setup.py", line 28, in <module>
    'License :: OSI Approved :: GNU General Public License (GPL)',
ImportError: No module named util
An error occurred when trying to install /var/lib/jenkins/zope/download-cache/dist/openpyxl-3.0.0.dev0.tar.gz. Look above this message for any errors that were output by easy_install.
While:
  Installing test.
  Getting distribution for 'openpyxl'.
```