### PR TITLE
Revert "Default to doing shallow clones with mr.developer"

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -90,8 +90,6 @@ allow-hosts =
     *.plone.org
 
 
-# Default to doing shallow clones with mr.developer
-git-clone-depth = 1
 
 # bin/test : A script running the tests of the configured package.
 [test]


### PR DESCRIPTION
Reverts 4teamwork/ftw-buildouts#141.

Using shallow clones on CI seems to require slightly more work in order to not cause issues. The original change was intended to simply upstream changes from the GEVER tests, if and only if it easily works for all CI tests without issue. Turns it doesn't.