### PR TITLE
Unpin collective.xmltestreport

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -93,35 +93,10 @@ allow-hosts =
 
 # bin/test : A script running the tests of the configured package.
 [test]
-recipe = zc.recipe.egg
+recipe = collective.xmltestreport
 eggs =
-    collective.xmltestreport
     ${buildout:test-egg}
-entry-points = test=collective.xmltestreport.runner:run_internal
-arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--test-path', '${buildout:directory}']
-initialization =
-    import os
-    sys.argv[0] = os.path.abspath(sys.argv[0])
-    test_directory = '${buildout:directory}/parts/test'
-    try: os.makedirs(test_directory)
-    except OSError: pass
-    os.chdir(test_directory)
-    os.environ['zope_i18n_compile_mo_files'] = 'true'
-    chameleon_cache_dir = '${buildout:directory}/parts/test/chameleon-cache'
-    try: os.makedirs(chameleon_cache_dir)
-    except OSError: pass
-    if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = chameleon_cache_dir
-scripts = test
-
-# collective.xmltestreport currently returns bad exit codes when installed as it
-# is intended. Therefore we manually install it and use run_internal instead of run.
-# See https://github.com/collective/collective.xmltestreport/issues/3
-#
-# recipe = collective.xmltestreport
-# eggs = ${buildout:test-egg}
-# script = test
-# defaults =
-#          ['-s', '${buildout:package-name}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml']
+defaults = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--test-path', '${buildout:directory}']
 
 
 
@@ -472,9 +447,3 @@ initialization =
         shell=True, stdout=subprocess.PIPE).stdout.read().strip()
     sys.argv.extend([pkgdir])
 scripts = dependencychecker
-
-
-
-[versions]
-# collective.xmltestreport: pinned down because of the z3c.recipe.scripts which results in version conflicts with the zope versions configuration.
-collective.xmltestreport = 1.2.6


### PR DESCRIPTION
The bug which is being circumvented by pinning `collective.xmltestreport` and having a manual entrypoint seems to be long gone and pinning it to such an old version with a custom entrypoint is a blocker for Python 3 compatibility.

If anything does pop up in the nightlies, I can move these fixes to those packages on a per package basis.