### PR TITLE
Pin isort to last minor version because jenkins failed buildouting

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -14,3 +14,6 @@ splinter = 0.6.0
 zc.buildout = >2
 setuptools =
 distribute =
+
+# Isort >= 4.3.0 prevented jenkins from a successful buildout (March 2019).
+isort = < 4.3.0a


### PR DESCRIPTION
Pinning isort to the last minor release solves this issue.

Problem:
```python
Installing isort.
While:
  Installing isort.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/var/lib/jenkins/zope/eggs/zc.buildout-2.4.5-py2.7.egg/zc/buildout/buildout.py", line 1992, in main
    getattr(buildout, command)(args)
  File "/var/lib/jenkins/zope/eggs/zc.buildout-2.4.5-py2.7.egg/zc/buildout/buildout.py", line 666, in install
    installed_files = self[part]._call(recipe.install)
  File "/var/lib/jenkins/zope/eggs/zc.buildout-2.4.5-py2.7.egg/zc/buildout/buildout.py", line 1407, in _call
    return f()
  File "/var/lib/jenkins/zope/eggs/zc.recipe.egg-1.3.2-py2.7.egg/zc/recipe/egg/egg.py", line 145, in install
    reqs, ws = self.working_set()
  File "/var/lib/jenkins/zope/eggs/zc.recipe.egg-1.3.2-py2.7.egg/zc/recipe/egg/egg.py", line 101, in working_set
    **kw)
  File "/var/lib/jenkins/zope/eggs/zc.buildout-2.4.5-py2.7.egg/zc/buildout/easy_install.py", line 849, in install
    return installer.install(specs, working_set)
  File "/var/lib/jenkins/zope/eggs/zc.buildout-2.4.5-py2.7.egg/zc/buildout/easy_install.py", line 695, in install
    requirements.extend(dist.requires(req.extras)[::-1])
  File "/var/lib/jenkins/zope/eggs/setuptools-19.2-py2.7.egg/pkg_resources/__init__.py", line 2640, in requires
    dm = self._dep_map
  File "/var/lib/jenkins/zope/eggs/setuptools-19.2-py2.7.egg/pkg_resources/__init__.py", line 2635, in _dep_map
    dm.setdefault(extra,[]).extend(parse_requirements(reqs))
  File "/var/lib/jenkins/zope/eggs/setuptools-19.2-py2.7.egg/pkg_resources/__init__.py", line 2988, in parse_requirements
    "version spec")
  File "/var/lib/jenkins/zope/eggs/setuptools-19.2-py2.7.egg/pkg_resources/__init__.py", line 2953, in scan_list
    raise RequirementParseError(msg, line, "at", line[p:])
RequirementParseError: Expected version spec in futures; python_version < "3.2" at ; python_version < "3.2"
Attempt 1 of "bin/buildout -n -t 5" failed.
```