### PR TITLE
Add separate test-versions files for the Plone major versions.

### DIFF
--- a/test-plone-4.0.x.cfg
+++ b/test-plone-4.0.x.cfg
@@ -2,6 +2,8 @@
 extends =
     http://dist.plone.org/release/4.0-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON26
 

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -5,6 +5,7 @@ extends =
     http://good-py.appspot.com/release/dexterity/1.2.1?plone=4.1.6
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON26
 

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.2-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.0.cfg
+++ b/test-plone-4.3.0.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.1.cfg
+++ b/test-plone-4.3.1.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.1/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.10.cfg
+++ b/test-plone-4.3.10.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.10/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.11.cfg
+++ b/test-plone-4.3.11.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.11/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.14.cfg
+++ b/test-plone-4.3.14.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.14/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.15.cfg
+++ b/test-plone-4.3.15.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.15/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.17.cfg
+++ b/test-plone-4.3.17.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.17/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.18.cfg
+++ b/test-plone-4.3.18.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.18/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.2.cfg
+++ b/test-plone-4.3.2.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.2/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.3.cfg
+++ b/test-plone-4.3.3.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.3/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.4.cfg
+++ b/test-plone-4.3.4.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.4/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.5.cfg
+++ b/test-plone-4.3.5.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.5/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.6.cfg
+++ b/test-plone-4.3.6.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.6/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.7/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.8.cfg
+++ b/test-plone-4.3.8.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.8/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.9.cfg
+++ b/test-plone-4.3.9.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/4.3.9/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,6 +4,7 @@ extends =
     http://dist.plone.org/release/4.3-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.2.cfg
+++ b/test-plone-5.0.2.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0.2/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.3.cfg
+++ b/test-plone-5.0.3.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0.3/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.4.cfg
+++ b/test-plone-5.0.4.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0.4/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.5.cfg
+++ b/test-plone-5.0.5.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0.5/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.6.cfg
+++ b/test-plone-5.0.6.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0.6/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.8.cfg
+++ b/test-plone-5.0.8.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0.8/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.cfg
+++ b/test-plone-5.0.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.0.x.cfg
+++ b/test-plone-5.0.x.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.0-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.1.0.cfg
+++ b/test-plone-5.1.0.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.1.0/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.1.1.cfg
+++ b/test-plone-5.1.1.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.1.1/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.1-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-plone-5.x.cfg
+++ b/test-plone-5.x.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 

--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -1,0 +1,3 @@
+# Plone 4.x version pinnings.
+
+[versions]

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -1,0 +1,3 @@
+# Plone 5.x version pinnings.
+
+[versions]

--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -1,7 +1,6 @@
 # This file contains general version pinnings, primarely
 # making sure that we have up to date buildout and setuptools / distribute
 # versions.
-# These versions may be used for Plone >= 4
 
 [versions]
 # splinter pins selenium in way incompatible with the plone KGS,


### PR DESCRIPTION
Since we have a lot of packages which test against a specific Plone version but also against the newest third party dependencies, we run into problems when the third part dependencies stop supporting our Plone version in a new release; we need to pin it down.

In order to do this in a controlled manner, this change introduces split version files for Plone 4 and 5 which all Plone test base configs extend from.

This will allow us to centrally propose different version pinnings for a package in Plone 4 and 5, while leaving the possibility to the package to override this pinning.

Impact: the `test-plone-4.0.x.cfg` was not consistent with other configs; it was liking the extend of `test-versions.cfg`. Other than that, this change should not have an impact yet to existing buildouts.