### PR TITLE
Pin collective.z3cform.datagridfield per Plone major release.

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -1,3 +1,4 @@
 # Plone 4.x version pinnings.
 
 [versions]
+collective.z3cform.datagridfield = <1.4a

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -1,3 +1,4 @@
 # Plone 5.x version pinnings.
 
 [versions]
+collective.z3cform.datagridfield = >=1.4


### PR DESCRIPTION
`collective.z3cform.datagridfield` has dropped Plone 4 support in the version `1.4.0`.

Therefore we should use:
- `<= 1.3.x` for Plone 4
- ` > 1.4.x` for Plone 5