### PR TITLE
path.py==12.0 has dropped Python 2 support.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -16,3 +16,6 @@ distribute =
 
 # Isort >= 4.3.0 prevented jenkins from a successful buildout (March 2019).
 isort = < 4.3.0a
+
+# path.py==12.0.1 has dropped Python 2.7 support.
+path.py = <12a


### PR DESCRIPTION
Pin down path.py to <=11.x because Python 2 support was dropped in the 12.x series.