### PR TITLE
Python 3 support

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -201,13 +201,12 @@ mode = 755
 
 # Downloads the default pycodestyle.cfg.
 [pycodestyle-cfg]
-recipe = collective.recipe.shelloutput
+recipe = collective.recipe.cmd
 cfgfile = ${buildout:directory}/parts/pycodestyle/pycodestyle.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pycodestyle.cfg
-commands =
-    cmd1 = mkdir -p `dirname ${pycodestyle-cfg:cfgfile}`
-    cmd2 = curl "${pycodestyle-cfg:cfgurl}" > "${pycodestyle-cfg:cfgfile}"
-
+cmds = 
+    mkdir -p `dirname ${pycodestyle-cfg:cfgfile}`
+    curl "${pycodestyle-cfg:cfgurl}" > "${pycodestyle-cfg:cfgfile}"
 
 
 # bin/pycodestyle : pycodestyle validation of the packages source.
@@ -244,12 +243,12 @@ initialization =
 
 # Downloads the default pydocstyle.cfg.
 [pydocstyle-cfg]
-recipe = collective.recipe.shelloutput
+recipe = collective.recipe.cmd
 cfgfile = ${buildout:directory}/parts/pydocstyle/pydocstyle.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pydocstyle.cfg
-commands =
-    cmd1 = mkdir -p `dirname ${pydocstyle-cfg:cfgfile}`
-    cmd2 = curl "${pydocstyle-cfg:cfgurl}" > "${pydocstyle-cfg:cfgfile}"
+cmds = 
+    mkdir -p `dirname ${pydocstyle-cfg:cfgfile}`
+    curl "${pydocstyle-cfg:cfgurl}" > "${pydocstyle-cfg:cfgfile}"
 
 
 
@@ -271,12 +270,12 @@ initialization =
 
 # Downloads the default isort.cfg.
 [isort-cfg]
-recipe = collective.recipe.shelloutput
+recipe = collective.recipe.cmd
 cfgfile = ${buildout:directory}/parts/isort/.isort.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/.isort.cfg
-commands =
-    cmd1 = mkdir -p `dirname ${isort-cfg:cfgfile}`
-    cmd2 = curl "${isort-cfg:cfgurl}" > "${isort-cfg:cfgfile}"
+cmds =
+    mkdir -p `dirname ${isort-cfg:cfgfile}`
+    curl "${isort-cfg:cfgurl}" > "${isort-cfg:cfgfile}"
 
 # bin/isort : isort validation of the packages source.
 [isort]
@@ -476,5 +475,6 @@ scripts = dependencychecker
 
 
 [versions]
+collective.recipe.cmd = 0.11
 # collective.xmltestreport: pinned down because of the z3c.recipe.scripts which results in version conflicts with the zope versions configuration.
 collective.xmltestreport = 1.2.6

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -93,12 +93,9 @@ allow-hosts =
 
 # bin/test : A script running the tests of the configured package.
 [test]
-recipe = zc.recipe.egg
+recipe = collective.xmltestreport
 eggs =
-    collective.xmltestreport
     ${buildout:test-egg}
-entry-points = test=collective.xmltestreport.runner:run_internal
-arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--test-path', '${buildout:directory}']
 initialization =
     import os
     sys.argv[0] = os.path.abspath(sys.argv[0])
@@ -112,17 +109,7 @@ initialization =
     except OSError: pass
     if 'CHAMELEON_CACHE' not in os.environ: os.environ['CHAMELEON_CACHE'] = chameleon_cache_dir
 scripts = test
-
-# collective.xmltestreport currently returns bad exit codes when installed as it
-# is intended. Therefore we manually install it and use run_internal instead of run.
-# See https://github.com/collective/collective.xmltestreport/issues/3
-#
-# recipe = collective.xmltestreport
-# eggs = ${buildout:test-egg}
-# script = test
-# defaults =
-#          ['-s', '${buildout:package-name}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml']
-
+defaults = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--test-path', '${buildout:directory}']
 
 
 # bin/coverage : A helper script generating a coverage report.
@@ -476,5 +463,4 @@ scripts = dependencychecker
 
 [versions]
 collective.recipe.cmd = 0.11
-# collective.xmltestreport: pinned down because of the z3c.recipe.scripts which results in version conflicts with the zope versions configuration.
-collective.xmltestreport = 1.2.6
+collective.xmltestreport = 2.0.1


### PR DESCRIPTION
Allows to run buildout with Python 3.7

Replace collective.recipe.shelloutput with collective.recipe.cmd
collective.recipe.shelloutput does not work with Python 3 and is no longer
maintained. collective.recipe.cmd does pretty much the same.

Update to latest collective.xmltestreport which is needed for Python 3 support.
Also remove workaround for bad exit code, as this has been fixed since a while.