### PR TITLE
Add config for testing against Plone 5.2

### DIFF
--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -1,0 +1,19 @@
+[buildout]
+extends =
+    https://dist.plone.org/release/5.2-latest/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
+
+jenkins_python = $PYTHON37
+
+
+
+[test]
+eggs +=
+    Pillow
+
+
+[versions]
+# Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
+zc.recipe.egg = 2.0.3

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -1,0 +1,19 @@
+[buildout]
+extends =
+    https://dist.plone.org/release/5.2-latest/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
+
+jenkins_python = $PYTHON27
+
+
+
+[test]
+eggs +=
+    Pillow
+
+
+[versions]
+# Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
+zc.recipe.egg = 2.0.3


### PR DESCRIPTION
How do we handle different Python version?
Make multiple config files? E.g. `test-plone-5.2.x-py37.cfg`
Or support multiple Pythons on Jenkins? E.g. `jenkins_python = $PYTHON27 $PYTHON37`