### PR TITLE
Pin Products.LDAPUserFolder

### DIFF
--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -16,3 +16,6 @@ eggs +=
 [versions]
 # Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
 zc.recipe.egg = 2.0.3
+
+# The newer versions of Products.LDAPUserFolder require Zope >= 4.0b5
+Products.LDAPUserFolder <= 2.27


### PR DESCRIPTION
Newer versions of Products.LDAPUserFolder require Zope >= 4.0b5.