### PR TITLE
Move path.py test version pinnings to less obtrusive file.

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -1,6 +1,14 @@
 # Plone 4.x version pinnings.
+# This file contains suggested version pinnings as constraints.
+# These version pinnings take effect when a project does not pin
+# versions at all.
 
 [versions]
 archetypes.multilingual = <2a
 collective.z3cform.datagridfield = <1.4a
 plone.app.multilingual = <2a
+
+# path.py==12.0.1 has dropped Python 2.7 support.
+# path.py==11.2.0 has started using importlib_metadata, which does not work well
+# with buildout.
+path.py = <11.2a

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -1,5 +1,13 @@
 # Plone 5.x version pinnings.
+# This file contains suggested version pinnings as constraints.
+# These version pinnings take effect when a project does not pin
+# versions at all.
 
 [versions]
 collective.z3cform.datagridfield = >=1.4
 plone.app.multilingual = >5a
+
+# path.py==12.0.1 has dropped Python 2.7 support.
+# path.py==11.2.0 has started using importlib_metadata, which does not work well
+# with buildout.
+path.py = <11.2a

--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -2,6 +2,10 @@
 # making sure that we have up to date buildout and setuptools / distribute
 # versions.
 
+# This file may be extended after the local versions.cfg, so be aware
+# that this file may override local version pinnings.
+# Consider putting pinnings in test-versions-plone-X.cfg
+
 [versions]
 # splinter pins selenium in way incompatible with the plone KGS,
 # therefore we remove the pinning from the KGS and let splinter decide.
@@ -16,6 +20,3 @@ distribute =
 
 # Isort >= 4.3.0 prevented jenkins from a successful buildout (March 2019).
 isort = < 4.3.0a
-
-# path.py==12.0.1 has dropped Python 2.7 support.
-path.py = <12a


### PR DESCRIPTION
Projects may extend `test-versions.cfg` after their local `versions.cfg` in their test buildout.
Putting a version pinning into `test-versions.cfg` has the effect that it overrides the local `versions.cfg` pinning in this setup.

This change includes these parts:

- The path.py version pinning is moved from `test-versions.cfg` into `test-versions-plone-?.cfg` files in order to make it less obtrusive.
- The test versions files are better documented in the comment: the purpuse of the `test-versions.cfg` is now to be included explicitly after the local `versions.cfg` and thus should only contain pinnings which we want to enforce. The `test-versions-plone-?.cfg` files are extended by ftw-buildouts base testing buildout configs and thus are only considered as a pinning suggestion which may be overridden by a `versions.cfg`.
- The version constraint of `path.py` is lowered to be `<11.2a`, since version `11.2.0` introduces a dependency onto `importlib_metadata` which does not wokr well with buildout causes strange errors.

@lukasgraf I think this should also solve the problem in GEVER and GEVER can keep including `test-versions.cfg` after the local `versions.cfg`.