### PR TITLE
Fix missing extends which breaks packages in plone 5.1.5

### DIFF
--- a/test-plone-5.1.5.cfg
+++ b/test-plone-5.1.5.cfg
@@ -3,6 +3,7 @@ extends =
     http://dist.plone.org/release/5.1.5/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
 
 jenkins_python = $PYTHON27
 


### PR DESCRIPTION
The `test-versions-plone-5.cfg` includes a version constraint for path.py, which has dropped python 2.7 in recent versions and so must not be installed. It also contains other constraints to ensure safety, they are not used everywhere though.

See https://github.com/4teamwork/ftw-buildouts/blob/776d4593457e383ca82e1eb4b180525b474286a5/test-versions-plone-5.cfg for more information.