### PR TITLE
Constrain PAM to a Plone 5.1 compatible version in test-versions-plone-5.cfg

### DIFF
--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -5,7 +5,10 @@
 
 [versions]
 collective.z3cform.datagridfield = >=1.4
-plone.app.multilingual = >5a
+
+# Constrain to PAM compatible with Plone 5.1. Once Plone 5.2 final is released,
+# we should probably split up this file into 5.1/5.2.
+plone.app.multilingual = >5a,<5.4
 
 # path.py==12.0.1 has dropped Python 2.7 support.
 # path.py==11.2.0 has started using importlib_metadata, which does not work well


### PR DESCRIPTION
`p.a.multilingual >= 5.4` is not compatible with Plone 5.1 any more, and in version `5.4.0` actually introduces a hard dependency on Plone 5.2.

Because Plone 5.1.x currently is the only Plone 5 version we test against, we constrain PAM to a version that works with it here. At a later point, the `test-versions-plone-5.cfg` file should probably be split up into 5.1 and 5.2 variants.

This should fix all those Plone 5 test failures we currently have.