### PR TITLE
Fix QA test config generation:

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -189,6 +189,8 @@ mode = 755
 # Downloads the default pycodestyle.cfg.
 [pycodestyle-cfg]
 recipe = collective.recipe.cmd
+on_install=true
+on_update=true
 cfgfile = ${buildout:directory}/parts/pycodestyle/pycodestyle.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pycodestyle.cfg
 cmds = 
@@ -231,6 +233,8 @@ initialization =
 # Downloads the default pydocstyle.cfg.
 [pydocstyle-cfg]
 recipe = collective.recipe.cmd
+on_install=true
+on_update=true
 cfgfile = ${buildout:directory}/parts/pydocstyle/pydocstyle.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pydocstyle.cfg
 cmds = 
@@ -258,6 +262,8 @@ initialization =
 # Downloads the default isort.cfg.
 [isort-cfg]
 recipe = collective.recipe.cmd
+on_install=true
+on_update=true
 cfgfile = ${buildout:directory}/parts/isort/.isort.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/.isort.cfg
 cmds =


### PR DESCRIPTION
The `collective.recipe.cmd` sections need an explicit `on_install=true` in order for them to run on install ([it defaults to `false`](https://github.com/collective/collective.recipe.cmd/blob/2141221cb2a215556d226aac63f487cb452fd6b9/collective/recipe/cmd/__init__.py#L49-L50)).

These were migrated from `collective.recipe.shelloutput` based sections in 4teamwork/ftw-buildouts#150 and apparently never tested.