### PR TITLE
Pin configparse version to 3.8.1.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -20,3 +20,6 @@ distribute =
 
 # Isort >= 4.3.0 prevented jenkins from a successful buildout (March 2019).
 isort = < 4.3.0a
+
+# configparser > 3.8.1 use buildout_scm leading to buildout issues.
+configparser = 3.8.1


### PR DESCRIPTION
pydocstyle requires configparse, and the latest version uses `setuptools_scm` (see https://github.com/jaraco/configparser/commit/e4a751c22c1f757ce7d47b39fccd79044b51bcab) which does not seem to work for us.

Pinning the version of configparse works when I do it in the `test-plone-4-3-x.cfg` of client policies, but I'm not sure how to test that pinning it here in `test-base.cfg` works too.