### PR TITLE
Make /apps/etc group writeable.

### DIFF
--- a/production-v2.cfg
+++ b/production-v2.cfg
@@ -44,4 +44,6 @@ command =
     # Make sure that "zope" have write access to solr-specific folders.
     chgrp --silent -R ${buildout:os-user} ${buildout:directory}/parts/solr-instance/logs
     chgrp --silent -R ${buildout:os-user} ${buildout:directory}/parts/solr-instance/solr-webapp
+    # Make sure that /apps/etc/**/* is group writeable.
+    chmod -R --silent g+rw,o+r /apps/etc/*
 update-command = ${:command}


### PR DESCRIPTION
In order for other deploy-members to be able to run buildout when another user has installed initially, it is necessary that all files in /apps/etc (which are usually generated by `ftw.recipe.deployment` ) are group-writeable.