### PR TITLE
Add proposed-versions section and unpin versions of setuptools and zc…

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -6,6 +6,10 @@
 # that this file may override local version pinnings.
 # Consider putting pinnings in test-versions-plone-X.cfg
 
+[proposed-versions]
+zc.buildout = >2
+setuptools =
+
 [versions]
 # splinter pins selenium in way incompatible with the plone KGS,
 # therefore we remove the pinning from the KGS and let splinter decide.
@@ -14,8 +18,8 @@ selenium =
 splinter = 0.6.0
 
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
-zc.buildout = >2
-setuptools =
+zc.buildout = ${proposed-versions:zc.buildout}
+setuptools = ${proposed-versions:setuptools}
 distribute =
 
 # Isort >= 4.3.0 prevented jenkins from a successful buildout (March 2019).


### PR DESCRIPTION
….buildout.

To use proposed-versions like https://github.com/4teamwork/ftw-buildouts#pinning-setuptools-and-buildout in `versions.cfg` the test-versions need to have this section as well (otherwise bootstrap will fail). In test we want to unpin the versions though, so that we can react to changes in setuptools and zc.buildout.