### PR TITLE
Fix proposed versions problem for testing

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -6,16 +6,24 @@
 # that this file may override local version pinnings.
 # Consider putting pinnings in test-versions-plone-X.cfg
 
+[proposed-versions]
+# This is required in projects where the version.cfg is used in testing
+# and contains version pinning using a proposed-versions variable.
+zc.buildout = >2
+setuptools =
+
 [versions]
+# Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
+# We cannot use ${proposed-versions:zc.buildout} here because buildout will break
+# in some cases.
+zc.buildout = >2
+setuptools =
+
 # splinter pins selenium in way incompatible with the plone KGS,
 # therefore we remove the pinning from the KGS and let splinter decide.
 selenium =
 # Splinter >= 0.7 is not compatible with ftw.testing.
 splinter = 0.6.0
-
-# Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
-zc.buildout = >2
-setuptools =
 
 # Isort >= 4.3.0 prevented jenkins from a successful buildout (March 2019).
 isort = < 4.3.0a

--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -16,7 +16,6 @@ splinter = 0.6.0
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
 zc.buildout = >2
 setuptools =
-distribute =
 
 # Isort >= 4.3.0 prevented jenkins from a successful buildout (March 2019).
 isort = < 4.3.0a


### PR DESCRIPTION
The production.cfg now provides proposed versions and policy projects should set the `zc.buildout` and `setuptools` versions with proposed-versions according to the docs.
But when setting the versions in the versions.cfg by using the proposed-versions variables, these variables are missing in testing because they are defined in `production.cfg`, which is not used there.

Therefore we need to provide proposed versions in the `test-versions.cfg` too.

We cannot use the variables in the same file in the versions section  because buildout will not substitute the variables when the `mr.developer` extension is used in certain ways. Thus we must define the versions for `zc.buildout` and `setuptools` twice in test-versions.cfg.

This is the successor of #162, which was revered in 61248c0.