### PR TITLE
Add test support for Plone 5.1.6.

### DIFF
--- a/test-plone-5.1.6.cfg
+++ b/test-plone-5.1.6.cfg
@@ -1,0 +1,19 @@
+[buildout]
+extends =
+    http://dist.plone.org/release/5.1.6/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
+
+jenkins_python = $PYTHON27
+
+
+
+[test]
+eggs +=
+    Pillow
+
+
+[versions]
+# Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
+zc.recipe.egg = 2.0.3


### PR DESCRIPTION
Add a `test-plone-5.1.6.cfg` buildout configuration file.

Copied from test-plone-5.1.5.cfg`