### PR TITLE
Refactor eventlistener definitions for HttpOk plugins.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -157,9 +157,12 @@ programs =
 eventlistener-memmon = Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
 eventlistener-httpok1 = HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]
 
+eventlisteners-httpok =
+    ${supervisor:eventlistener-httpok1}
+
 eventlisteners =
     ${supervisor:eventlistener-memmon}
-    ${supervisor:eventlistener-httpok1}
+    ${supervisor:eventlisteners-httpok}
 
 
 

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -15,7 +15,7 @@ programs +=
     20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
-eventlisteners +=
+eventlisteners-httpok +=
     ${supervisor:eventlistener-httpok2}
 
 

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -23,7 +23,7 @@ programs +=
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
-eventlisteners +=
+eventlisteners-httpok +=
     ${supervisor:eventlistener-httpok2}
     ${supervisor:eventlistener-httpok3}
 

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -31,7 +31,7 @@ programs +=
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok4 = HttpOk4 TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/${buildout:supervisor-httpok-view}]
-eventlisteners +=
+eventlisteners-httpok +=
     ${supervisor:eventlistener-httpok2}
     ${supervisor:eventlistener-httpok3}
     ${supervisor:eventlistener-httpok4}

--- a/zeoclients/6.cfg
+++ b/zeoclients/6.cfg
@@ -47,7 +47,7 @@ eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p ins
 eventlistener-httpok4 = HttpOk4 TICK_60 ${buildout:bin-directory}/httpok [-p instance4 ${buildout:supervisor-httpok-options} http://localhost:${instance4:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok5 = HttpOk5 TICK_60 ${buildout:bin-directory}/httpok [-p instance5 ${buildout:supervisor-httpok-options} http://localhost:${instance5:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok6 = HttpOk6 TICK_60 ${buildout:bin-directory}/httpok [-p instance6 ${buildout:supervisor-httpok-options} http://localhost:${instance6:http-address}/${buildout:supervisor-httpok-view}]
-eventlisteners +=
+eventlisteners-httpok +=
     ${supervisor:eventlistener-httpok2}
     ${supervisor:eventlistener-httpok3}
     ${supervisor:eventlistener-httpok4}

--- a/zeoclients/8.cfg
+++ b/zeoclients/8.cfg
@@ -63,7 +63,7 @@ eventlistener-httpok5 = HttpOk5 TICK_60 ${buildout:bin-directory}/httpok [-p ins
 eventlistener-httpok6 = HttpOk6 TICK_60 ${buildout:bin-directory}/httpok [-p instance6 ${buildout:supervisor-httpok-options} http://localhost:${instance6:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok7 = HttpOk7 TICK_60 ${buildout:bin-directory}/httpok [-p instance7 ${buildout:supervisor-httpok-options} http://localhost:${instance7:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok8 = HttpOk8 TICK_60 ${buildout:bin-directory}/httpok [-p instance8 ${buildout:supervisor-httpok-options} http://localhost:${instance8:http-address}/${buildout:supervisor-httpok-view}]
-eventlisteners +=
+eventlisteners-httpok +=
     ${supervisor:eventlistener-httpok2}
     ${supervisor:eventlistener-httpok3}
     ${supervisor:eventlistener-httpok4}

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -43,7 +43,7 @@ programs +=
     20 instancepub (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
-eventlisteners +=
+eventlisteners-httpok +=
     ${supervisor:eventlistener-httpokpub}
 
 

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -14,7 +14,7 @@ programs +=
     20 instancepub (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
-eventlisteners +=
+eventlisteners-httpok +=
     ${supervisor:eventlistener-httpokpub}
 
 


### PR DESCRIPTION
This is a refactoring for how we include the `HttpOk` plugins in the `${supervisor:eventlisteners}` variable, so that all **`HttpOk` plugins can easily be removed** from an extending buildout, without having to override the entire `${supervisor:eventlisteners}`.

To achive this, a new variable `${supervisor:eventlisteners-httpok}` is introduced that collects all HttpOk plugins (so the 1-8.cfgs append to that variable), and _that_ then gets included once in `${supervisor:eventlisteners}`.

To disable all HttpOk plugins, one can therefore set that variable to the empty string (_after_ `production.cfg` and `zeoclients/<n>.cfg`):

```ini
[supervisor]
eventlisteners-httpok =
```

Tested:
- `parts/supervisor/supervisord.conf` stays the same (when tested with a prod buildout using a single ZEO client, and another one based on `zeoclients/4.cfg`)
- Getting rid of all HttpOk plugins actually works