### PR TITLE
Refactor warmup.cfg so it can easily be disabled.

### DIFF
--- a/warmup.cfg
+++ b/warmup.cfg
@@ -1,9 +1,18 @@
 [buildout]
 parts +=
+    ${buildout:warmup-parts}
+
+instance-eggs +=
+    ${buildout:warmup-eggs}
+
+warmup-eggs = collective.warmup
+warmup-ini-path = ${buildout:parts-directory}/warmup/warmup.ini
+warmup-parts =
     make-warmup-config-file
     warmup
-
-instance-eggs += collective.warmup
+warmup-instance-env-vars =
+    WARMUP_BIN ${buildout:directory}/bin/warmup
+    WARMUP_INI ${buildout:warmup-ini-path}
 
 
 
@@ -22,15 +31,13 @@ url-sections =
 
 
 [instance0]
-environment-vars +=
-    WARMUP_BIN ${buildout:directory}/bin/warmup
-    WARMUP_INI ${make-warmup-config-file:output}
+environment-vars += ${buildout:warmup-instance-env-vars}
 
 
 
 [make-warmup-config-file]
 recipe = collective.recipe.template
-output = ${buildout:parts-directory}/warmup/warmup.ini
+output = ${buildout:warmup-ini-path}
 input = inline:
     [warmup]
     enabled = True
@@ -45,5 +52,5 @@ input = inline:
 
 [warmup]
 recipe = zc.recipe.egg:scripts
-eggs = collective.warmup
+eggs = ${buildout:warmup-eggs}
 dependent-scripts = false


### PR DESCRIPTION
This refactors `warmup.cfg` so that it can easily be disabled by doing

```ini
[buildout]
warmup-parts =
warmup-eggs =
warmup-instance-env-vars =
```
in a cfg that comes after `warmup.cfg`.

**Notes**:

- Moving out the `warmup-*` variables [over here to `production.cfg`](https://github.com/4teamwork/ftw-buildouts/blob/0b2a355388377dd658009a1ef7f5b70c418c8530/production.cfg#L61) unfortunately did not work because buildout then fails to resolve variable contents because of circular dependencies.
- `warmup-ini-path` had to be factored out into its own variable because otherwise it would have lead to the unpinned-recipe-bug (see #34)


**Tested**:
- Contents of `parts/warmup/warmup.ini`, `bin/warmup` and `parts/instance1/etc/zope.conf` stay the same for a buildout extending from `warmup.cfg`