### PR TITLE
Ensure minimum six version for tests is 1.12.0

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -30,3 +30,7 @@ isort = < 4.3.0a
 
 # configparser > 3.8.1 use buildout_scm leading to buildout issues.
 configparser = 3.8.1
+
+# six 1.12.0 provides ensure_text, ensure_binary and ensure_str helpers
+# which we use when porting to Python 3
+six = >=1.12.0


### PR DESCRIPTION
We require at least six 1.12.0 in packages ported to Python 3.
However Plone < 5.2 pins six to a lower version.