### PR TITLE
Format XML: support custom params for find.

### DIFF
--- a/format-xml.cfg
+++ b/format-xml.cfg
@@ -35,11 +35,13 @@ on-update = True
 recipe = collective.recipe.template
 output = ${buildout:directory}/bin/format-all-xmls
 mode = 0755
+standard-find-params = ! -name definition.xml ! -name solrconfig.xml
+find-params =
 input = inline:
     #!/usr/bin/env sh
     set -euo pipefail
     IFS=$'\n'
     pkgdir=$(${buildout:bin-directory}/package-directory)
     formatter="${buildout:bin-directory}/format-xml"
-    $formatter $(find $pkgdir \! -path "*/upgrades/*" -type f \( -iname \*.xml -o -iname \*.zcml \) ! -name definition.xml ! -name solrconfig.xml) "$@"
+    $formatter $(find $pkgdir \! -path "*/upgrades/*" -type f \( -iname \*.xml -o -iname \*.zcml \) ${:standard-find-params} ${:find-params}) "$@"
     exit $?


### PR DESCRIPTION
Make it possible to use custom params for finding XMLs to format.

- "find-params" allows to add more params, such as custom ignores
- "standard-find-params" contains the standard params and makes it possible to remove standard ignores such as definition.xml.