### PR TITLE
Pin down setuptools and more-itertools for Python 2

### DIFF
--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -3,7 +3,7 @@ extends =
     https://dist.plone.org/release/5.2-latest/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5-py37.cfg
 
 jenkins_python = $PYTHON37
 

--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -12,3 +12,7 @@ plone.app.multilingual = <2a
 # path.py==11.2.0 has started using importlib_metadata, which does not work well
 # with buildout.
 path.py = <11.2a
+
+# Python 2 compatibility versions (where newer versions drop Python 2 support).
+setuptools = <45.0
+more-itertools = <6.0.0

--- a/test-versions-plone-5-py37.cfg
+++ b/test-versions-plone-5-py37.cfg
@@ -14,7 +14,3 @@ plone.app.multilingual = >5a,<5.4
 # path.py==11.2.0 has started using importlib_metadata, which does not work well
 # with buildout.
 path.py = <11.2a
-
-# Python 2 compatibility versions (where newer versions drop Python 2 support).
-setuptools = <45.0
-more-itertools = <6.0.0


### PR DESCRIPTION
Attempt to fix our broken builds. Currently a lot of python2 builds are failing because `setuptools` was not pinned up to now:

Example: https://ci.4teamwork.ch/builds/301717/tasks/496024

setuptools and more-itertools need to be pinned down for python2 buildouts to a version that has still python2 support.

In order for that to work properly in Plone 5, we need to split up the versions file into python 2 and python 3 versions.