### PR TITLE
Introduce a supervisor-autostart variable for instanceX sections:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -252,6 +252,9 @@ Here is a full example, below is the detail explanation:
         <include package="my.package" file="meta.zcml" />
         <myPackageSecurity token="123123" />
 
+    [instance4]
+    supervisor-autostart = false
+
 
 These are the most common configuration settings.
 You can also override any options in the sections of the parts.
@@ -281,6 +284,7 @@ Details:
 - ``zcml-additional-fragments`` - Define additional zcml to load. See the `Additional ZCML`_ section.
 - ``instance-zcml`` - Add packages to the instances `zcml` list.
 - ``instance-early-zcml`` - Add packages on top of the instances `zcml` list.
+- ``supervisor-autostart`` - by default, all instances except instance0 will be automatically started in supervisor. By setting ``supervisor-autostart`` to ``false`` for a specific ``[instanceX]`` section, this can be overridden.
 
 
 HAProxy / Supervisor integration

--- a/production.cfg
+++ b/production.cfg
@@ -102,6 +102,7 @@ shared-blob = on
 user = zopemaster:admin
 chameleon-cache = ${buildout:directory}/var/${:_buildout_section_name_}/chameleon-cache
 http-address = 1${buildout:deployment-number}00
+supervisor-autostart = false
 eggs =
     Plone
     ${buildout:instance-eggs}
@@ -129,6 +130,7 @@ initialization =
 
 [instance1]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}01
 
 
@@ -152,7 +154,7 @@ program-zeo = 10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} tr
 programs =
     ${supervisor:program-zeo}
     90 instance0 (${buildout:supervisor-client-process-opts} autostart=false) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
-    20 instance1 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
+    20 instance1 (${buildout:supervisor-client-process-opts} autostart=${instance1:supervisor-autostart}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
 
 eventlistener-memmon = Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]
 eventlistener-httpok1 = HttpOk1 TICK_60 ${buildout:bin-directory}/httpok [-p instance1 ${buildout:supervisor-httpok-options} http://localhost:${instance1:http-address}/${buildout:supervisor-httpok-view}]

--- a/production.cfg
+++ b/production.cfg
@@ -153,7 +153,7 @@ program-zeo = 10 zeo (startsecs=5) ${zeo:location}/bin/runzeo ${zeo:location} tr
 
 programs =
     ${supervisor:program-zeo}
-    90 instance0 (${buildout:supervisor-client-process-opts} autostart=false) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
+    90 instance0 (${buildout:supervisor-client-process-opts} autostart=${instance0:supervisor-autostart}) ${buildout:bin-directory}/instance0 [console] true ${buildout:os-user}
     20 instance1 (${buildout:supervisor-client-process-opts} autostart=${instance1:supervisor-autostart}) ${buildout:bin-directory}/instance1 [console] true ${buildout:os-user}
 
 eventlistener-memmon = Memmon TICK_60 ${buildout:bin-directory}/memmon [${buildout:supervisor-memmon-options}]

--- a/zeoclients/2.cfg
+++ b/zeoclients/2.cfg
@@ -7,12 +7,13 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 
 [instance2]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}02
 
 
 [supervisor]
 programs +=
-    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts} autostart=${instance2:supervisor-autostart}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners-httpok +=

--- a/zeoclients/3.cfg
+++ b/zeoclients/3.cfg
@@ -8,18 +8,20 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 
 [instance2]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}02
 
 
 [instance3]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}03
 
 
 [supervisor]
 programs +=
-    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
-    20 instance3 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts} autostart=${instance2:supervisor-autostart}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (${buildout:supervisor-client-process-opts} autostart=${instance3:supervisor-autostart}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/4.cfg
+++ b/zeoclients/4.cfg
@@ -9,24 +9,27 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 
 [instance2]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}02
 
 
 [instance3]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}03
 
 
 [instance4]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}04
 
 
 [supervisor]
 programs +=
-    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
-    20 instance3 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
-    20 instance4 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts} autostart=${instance2:supervisor-autostart}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (${buildout:supervisor-client-process-opts} autostart=${instance3:supervisor-autostart}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
+    20 instance4 (${buildout:supervisor-client-process-opts} autostart=${instance4:supervisor-autostart}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/6.cfg
+++ b/zeoclients/6.cfg
@@ -11,36 +11,41 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 
 [instance2]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}02
 
 
 [instance3]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}03
 
 
 [instance4]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}04
 
 
 [instance5]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}05
 
 
 [instance6]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}06
 
 
 [supervisor]
 programs +=
-    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
-    20 instance3 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
-    20 instance4 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
-    20 instance5 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance5 [console] true ${buildout:os-user}
-    20 instance6 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance6 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts} autostart=${instance2:supervisor-autostart}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (${buildout:supervisor-client-process-opts} autostart=${instance3:supervisor-autostart}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
+    20 instance4 (${buildout:supervisor-client-process-opts} autostart=${instance4:supervisor-autostart}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
+    20 instance5 (${buildout:supervisor-client-process-opts} autostart=${instance5:supervisor-autostart}) ${buildout:bin-directory}/instance5 [console] true ${buildout:os-user}
+    20 instance6 (${buildout:supervisor-client-process-opts} autostart=${instance6:supervisor-autostart}) ${buildout:bin-directory}/instance6 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/8.cfg
+++ b/zeoclients/8.cfg
@@ -13,48 +13,55 @@ supervisor-haproxy-programs = instance1:${buildout:supervisor-haproxy-backend}/$
 
 [instance2]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}02
 
 
 [instance3]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}03
 
 
 [instance4]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}04
 
 
 [instance5]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}05
 
 
 [instance6]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}06
 
 
 [instance7]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}07
 
 
 [instance8]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}08
 
 
 [supervisor]
 programs +=
-    20 instance2 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
-    20 instance3 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
-    20 instance4 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
-    20 instance5 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance5 [console] true ${buildout:os-user}
-    20 instance6 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance6 [console] true ${buildout:os-user}
-    20 instance7 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance7 [console] true ${buildout:os-user}
-    20 instance8 (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instance8 [console] true ${buildout:os-user}
+    20 instance2 (${buildout:supervisor-client-process-opts} autostart=${instance2:supervisor-autostart}) ${buildout:bin-directory}/instance2 [console] true ${buildout:os-user}
+    20 instance3 (${buildout:supervisor-client-process-opts} autostart=${instance3:supervisor-autostart}) ${buildout:bin-directory}/instance3 [console] true ${buildout:os-user}
+    20 instance4 (${buildout:supervisor-client-process-opts} autostart=${instance4:supervisor-autostart}) ${buildout:bin-directory}/instance4 [console] true ${buildout:os-user}
+    20 instance5 (${buildout:supervisor-client-process-opts} autostart=${instance5:supervisor-autostart}) ${buildout:bin-directory}/instance5 [console] true ${buildout:os-user}
+    20 instance6 (${buildout:supervisor-client-process-opts} autostart=${instance6:supervisor-autostart}) ${buildout:bin-directory}/instance6 [console] true ${buildout:os-user}
+    20 instance7 (${buildout:supervisor-client-process-opts} autostart=${instance7:supervisor-autostart}) ${buildout:bin-directory}/instance7 [console] true ${buildout:os-user}
+    20 instance8 (${buildout:supervisor-client-process-opts} autostart=${instance8:supervisor-autostart}) ${buildout:bin-directory}/instance8 [console] true ${buildout:os-user}
 
 eventlistener-httpok2 = HttpOk2 TICK_60 ${buildout:bin-directory}/httpok [-p instance2 ${buildout:supervisor-httpok-options} http://localhost:${instance2:http-address}/${buildout:supervisor-httpok-view}]
 eventlistener-httpok3 = HttpOk3 TICK_60 ${buildout:bin-directory}/httpok [-p instance3 ${buildout:supervisor-httpok-options} http://localhost:${instance3:http-address}/${buildout:supervisor-httpok-view}]

--- a/zeoclients/publisher-sender.cfg
+++ b/zeoclients/publisher-sender.cfg
@@ -27,6 +27,7 @@ zcml =
 
 [instancepub]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}10
 zope-conf-additional =
     ${instance0:zope-conf-additional}
@@ -40,7 +41,7 @@ zope-conf-additional =
 
 [supervisor]
 programs +=
-    20 instancepub (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
+    20 instancepub (${buildout:supervisor-client-process-opts} autostart=${instancepub:supervisor-autostart}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners-httpok +=

--- a/zeoclients/publisher.cfg
+++ b/zeoclients/publisher.cfg
@@ -5,13 +5,14 @@ parts +=
 
 [instancepub]
 <= instance0
+supervisor-autostart = true
 http-address = 1${buildout:deployment-number}10
 
 
 
 [supervisor]
 programs +=
-    20 instancepub (${buildout:supervisor-client-process-opts}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
+    20 instancepub (${buildout:supervisor-client-process-opts} autostart=${instancepub:supervisor-autostart}) ${buildout:bin-directory}/instancepub [console] true ${buildout:os-user}
 
 eventlistener-httpokpub = HttpOkpub TICK_60 ${buildout:bin-directory}/httpok [-p instancepub ${buildout:supervisor-httpok-options} http://localhost:${instancepub:http-address}/${buildout:supervisor-httpok-view}]
 eventlisteners-httpok +=


### PR DESCRIPTION
This variable allows to control supervisor autostart behavior on a per-instance basis without having to override the entire `programs` variable or do error-prone line removal from it.

In particular, this allows us to get rid of this fragile hack:
https://github.com/4teamwork/opengever.zug/blob/master/base-prod.cfg#L27-L35

*(Tested locally with a buildout extending from `production.cfg` and `zeoclients/2.cfg`, works exactly as I intended it to)*