### PR TITLE
Introduce solr-host and solr-listen-address variables

### DIFF
--- a/solr-v2.cfg
+++ b/solr-v2.cfg
@@ -2,17 +2,24 @@
 solr-core-name = plone
 solr-port = 1${buildout:deployment-number}30
 
+# Hostname that ftw.solr will connect to.
+solr-host = localhost
+
+# Address that the Solr server will bind to
+solr-listen-address = localhost
+
 parts += solr
 
 zcml-additional-fragments +=
     <configure xmlns:solr="http://namespaces.plone.org/solr">
-        <solr:connection host="localhost"
+        <solr:connection host="${:solr-host}"
                          port="${:solr-port}"
                          base="/solr/${:solr-core-name}"/>
     </configure>
 
 [solr]
 recipe = ftw.recipe.solr
+host = ${buildout:solr-listen-address}
 port = ${buildout:solr-port}
 cores = ${buildout:solr-core-name}
 


### PR DESCRIPTION
Introduce solr-host and solr-listen-address variables:

- solr-host is the hostname that ftw.solr will connect to.
- solr-listen-address is the address that the Solr server will bind to.

In the simplest case where Solr runs on the same server as the Zope instance, these will both be identical (localhost).

For setups where ftw.solr connects to a remote Solr however, these need to be set separately. For example:

`solr-host` -> `solr-master.example.org`
`solr-listen-address` -> `0.0.0.0`