### PR TITLE
Factor out Solr ZCML into its own buildout variable

### DIFF
--- a/solr-v2.cfg
+++ b/solr-v2.cfg
@@ -10,12 +10,14 @@ solr-listen-address = localhost
 
 parts += solr
 
-zcml-additional-fragments +=
+solr-zcml =
     <configure xmlns:solr="http://namespaces.plone.org/solr">
         <solr:connection host="${:solr-host}"
                          port="${:solr-port}"
                          base="/solr/${:solr-core-name}"/>
     </configure>
+
+zcml-additional-fragments += ${buildout:solr-zcml}
 
 [solr]
 recipe = ftw.recipe.solr


### PR DESCRIPTION
Factor out Solr ZCML into its own buildout variable. This is necessary to be able to easily override (i.e. completely replace) the Solr ZCML in a buildout extending from `solr-v2.cfg`.

More specifically, we need to add the `upload_blobs` ZCML attribute for deployments with Solr master/slave replication. But because this ZCML attribute doesn't exist yet in older versions of `ftw.solr`, it can't simply be added to ftw-buildouts with a default of `"false"`.

We therefore need to be able to just override the Solr ZCML for these deployments, without having to mess with the entire `zcml-additional-fragments`.