### PR TITLE
zipp 2.0.0 is no longer Python 2 compatible.

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -16,3 +16,4 @@ path.py = <11.2a
 # Python 2 compatibility versions (where newer versions drop Python 2 support).
 setuptools = <45.0
 more-itertools = <6.0.0
+zipp = >=0.5, <2a

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -18,3 +18,4 @@ path.py = <11.2a
 # Python 2 compatibility versions (where newer versions drop Python 2 support).
 setuptools = <45.0
 more-itertools = <6.0.0
+zipp = >=0.5, <2a


### PR DESCRIPTION
Pin down zipp to <2a for Python 2 builds. Then >=0.5 constraint was already in there, not sure where it comes from.