### PR TITLE
Use https insted of http for repo1.maven.org.

### DIFF
--- a/plone-development-tika.cfg
+++ b/plone-development-tika.cfg
@@ -23,7 +23,7 @@ zcml =
 
 [tika-app-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
 md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
 filename = tika-app.jar
@@ -32,7 +32,7 @@ mode = 664
 
 [tika-server-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
 md5sum = 0f70548f233ead7c299bf7bc73bfec26
 download-only = true
 filename = tika-server.jar


### PR DESCRIPTION
Entering the site over http causes a "501 HTTPS Required" error. So http doesn't work anymore for repo1.maven.org. So I had to switch the url to https.