### PR TITLE
Use ssl for maven.org.

### DIFF
--- a/tika-jaxrs-server.cfg
+++ b/tika-jaxrs-server.cfg
@@ -24,7 +24,7 @@ zcml =
 [tika-app-download]
 recipe = hexagonit.recipe.download
 # Don't upgrade tika version without running integration tests!
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
 md5sum = 2124a77289efbb30e7228c0f7da63373
 download-only = true
 filename = ${tika:filename-app}
@@ -34,7 +34,7 @@ mode = 664
 [tika-server-download]
 recipe = hexagonit.recipe.download
 # Don't upgrade tika version without running integration tests!
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
 md5sum = 0f70548f233ead7c299bf7bc73bfec26
 download-only = true
 filename = ${tika:filename-server}


### PR DESCRIPTION
maven.org does not allow non-SSL connections. The buildout fails therefore without this change.