### PR TITLE
Add configurable supervisor autostart for solr.

### DIFF
--- a/solr-v2.cfg
+++ b/solr-v2.cfg
@@ -24,8 +24,9 @@ recipe = ftw.recipe.solr
 host = ${buildout:solr-listen-address}
 port = ${buildout:solr-port}
 cores = ${buildout:solr-core-name}
+supervisor-autostart = true
 
 [supervisor]
 programs +=
-    10 solr (startsecs=5 stopasgroup=true) ${buildout:bin-directory}/solr [console] true ${buildout:os-user}
+    10 solr (startsecs=5 stopasgroup=true autostart=${solr:supervisor-autostart}) ${buildout:bin-directory}/solr [console] true ${buildout:os-user}
 


### PR DESCRIPTION
This variable allows to control supervisor autostart behavior without having to override the entire programs variable or do error-prone line removal from it.

It allows to temporarily disable booting a solr instance while rolling out solr for certain customers.

Follow up of https://github.com/4teamwork/ftw-buildouts/pull/176 which already added this variable to the `instanceX` sections.

_(Tested on dev.onegovgever.ch with local modification works exactly as i intended it to)_