### PR TITLE
jenkins-run: always use Python 2.7.

### DIFF
--- a/jenkins-run.py
+++ b/jenkins-run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 
 """This script is called by a jenkins job.


### PR DESCRIPTION
Since we have lost the jenkins setup on slave 2 (django-only-slave) the jenkins-run script is executed with python 3 when run in a python 3 virtual env. It used to work before and does no longer and I do not understand why.

Now we just enforce python 2.7 and it should work again.