### PR TITLE
Pin package "inflection" to <0.4.0 for python2.

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -17,3 +17,4 @@ path.py = <11.2a
 setuptools = <45.0
 more-itertools = <6.0.0
 zipp = >=0.5, <2a
+inflection = <0.4.0

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -19,3 +19,4 @@ path.py = <11.2a
 setuptools = <45.0
 more-itertools = <6.0.0
 zipp = >=0.5, <2a
+inflection = <0.4.0


### PR DESCRIPTION
The package `inflection` has dropped python2 support in version 0.4.0 according to https://github.com/jpvanhal/inflection/releases/tag/0.4.0. We should use a lower version when running against python2. Thus i'm adapting both base files for Plone 4 and Plone 5 where it runs against python2.

Interstingly only version 0.5.0 started to really break things for me. So if someone needs 0.4.0 for some reason we might be able to change the version constraint. But i'd prefer to go with what the package announced officially, so i'd suggest to try this change first and see it if breaks something for us.

This supersedes https://github.com/4teamwork/ftw.mail/pull/57 where i wanted to fix the issue for one affected package only. Since `inflection` is a dependency of `ftw.upgrade` https://github.com/4teamwork/ftw.upgrade/blob/b20ac0d087cf16f4ac7253e5658d617569f447fd/setup.py#L63 which is used in almost all of our deployments  the change might be better placed in here, thx @mbaechtold for the suggestion.