### PR TITLE
Pin down setuptools.

### DIFF
--- a/test-javascript.cfg
+++ b/test-javascript.cfg
@@ -30,3 +30,6 @@ input = inline:
 
 output = ${buildout:directory}/bin/test-jenkins
 mode = 755
+
+[versions]
+setuptools = <45.0


### PR DESCRIPTION
Newer setuptools versions are not compatible anymore.

We could also pin them down in `test-versions.cfg`, but I'm not quite sure if not too much is extending from that.