### PR TITLE
Pin down setuptools.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -10,14 +10,14 @@
 # This is required in projects where the version.cfg is used in testing
 # and contains version pinning using a proposed-versions variable.
 zc.buildout = >2
-setuptools =
+setuptools = <45.0
 
 [versions]
 # Use the newest packaging tools so that it is compatible with the newest bootstrap.py.
 # We cannot use ${proposed-versions:zc.buildout} here because buildout will break
 # in some cases.
 zc.buildout = >2
-setuptools =
+setuptools = <45.0
 
 # splinter pins selenium in way incompatible with the plone KGS,
 # therefore we remove the pinning from the KGS and let splinter decide.


### PR DESCRIPTION
Setuptools are not Python 2.7 compatible from version 46 onwards. Therefore we need to pin them down in order to make the buildout with Python 2.7 work.

For Python 3 it might make sense to create another `test-versions-3.cfg` or alike to enable differentiating between the major jump.