### PR TITLE
Bootstrap with setuptools 44.1.1

### DIFF
--- a/jenkins-run.py
+++ b/jenkins-run.py
@@ -73,7 +73,7 @@ class Main(object):
 
         else:
             # we use a regular python to bootstrap
-            cmd = '%s bootstrap.py' % python_path
+            cmd = '%s bootstrap.py --setuptools-version 44.1.1' % python_path
 
         runcmd_with_retries(
             cmd,


### PR DESCRIPTION
Bootstrapping with the default version 33.1.1 no longer works because of SSL certificate verification issues.

This requires a current `bootstrap.py` script version 2015-07-01 or later from https://bootstrap.pypa.io/bootstrap-buildout.py)