### PR TITLE
Fix version conflict causing plone buildout to fail

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -18,3 +18,4 @@ setuptools = <45.0
 more-itertools = <6.0.0
 zipp = >=0.5, <2a
 inflection = <0.4.0
+importlib-metadata = <3a

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -20,3 +20,4 @@ setuptools = <45.0
 more-itertools = <6.0.0
 zipp = >=0.5, <2a
 inflection = <0.4.0
+importlib-metadata = <3a


### PR DESCRIPTION
importlib-metadata >= 3.0 is no longer python 2 compatible

Example fail: https://ci.4teamwork.ch/builds/413934/tasks/727082
importlib-metadata: https://github.com/python/importlib_metadata/blob/7f292bc63c5270bb6631819d60f3b6c64693e621/setup.cfg#L17