### PR TITLE
Add PloneHotfix20210518 for Plone 4.3.20.

### DIFF
--- a/bin/cibuild
+++ b/bin/cibuild
@@ -3,6 +3,6 @@
 set -e pipefail
 cd "$(dirname "$0")/../production-versions-buildout"
 
-$PYTHON27 bootstrap.py
+$PYTHON27 bootstrap.py --setuptools-version 44.1.1
 ./bin/buildout buildout:allow-picked-versions=false
 echo $?

--- a/hotfixes/4.3.20.cfg
+++ b/hotfixes/4.3.20.cfg
@@ -1,3 +1,7 @@
 [buildout]
 
 hotfix-eggs =
+    Products.PloneHotfix20210518
+
+[versions]
+Products.PloneHotfix20210518 = 1.2

--- a/production-versions-buildout/buildout.cfg
+++ b/production-versions-buildout/buildout.cfg
@@ -11,8 +11,8 @@ extends =
     ../haproxy.cfg
     ../maintenance-server.cfg
 
-    http://dist.plone.org/release/4.3.18/versions.cfg
-    ../hotfixes/4.3.18.cfg
+    http://dist.plone.org/release/4.3.20/versions.cfg
+    ../hotfixes/4.3.20.cfg
 
 
 deployment-number = 01

--- a/production-versions-buildout/buildout.cfg
+++ b/production-versions-buildout/buildout.cfg
@@ -28,6 +28,6 @@ versions = ../production.cfg
 
 
 [versions]
-zc.buildout = ${proposed-versions:zc.buildout}
-setuptools = ${proposed-versions:setuptools}
+zc.buildout = 2.13.3
+setuptools = 44.1.1
 ftw.recipe.checkversions = 1.2.1


### PR DESCRIPTION
⚠️  Please only merge on 25th of Mai 2021 (After SaaS GEVER Release on 24th of Mai).

Changes:
- Add PloneHotfix20210518 for Plone 4.3.20 only. I did not want to interfere with other non-GEVER Plone installations.
- Also make sure self test work again by explicitly buildouting with specific setuptools and by pinning/updating some versions
 