### PR TITLE
Bump PloneHotfix20210518 for Plone 4.3.20 to 1.4.

### DIFF
--- a/hotfixes/4.3.20.cfg
+++ b/hotfixes/4.3.20.cfg
@@ -4,4 +4,4 @@ hotfix-eggs =
     Products.PloneHotfix20210518
 
 [versions]
-Products.PloneHotfix20210518 = 1.2
+Products.PloneHotfix20210518 = 1.4


### PR DESCRIPTION
⚠️ Please only merge on 22th of June 2021 (After SaaS GEVER Release on 21th of June).

As is traditional we have several rleleases for the hotfix. See https://pypi.org/project/Products.PloneHotfix20210518/ for details.
 