### PR TITLE
Bump PloneHotfix20210518 for Plone 4.3.20 to 1.5.

### DIFF
--- a/hotfixes/4.3.20.cfg
+++ b/hotfixes/4.3.20.cfg
@@ -4,4 +4,4 @@ hotfix-eggs =
     Products.PloneHotfix20210518
 
 [versions]
-Products.PloneHotfix20210518 = 1.4
+Products.PloneHotfix20210518 = 1.5


### PR DESCRIPTION
As is traditional we have several releases for the hotfix. It also includes more changes/fixes than the original one. See https://plone.org/news/2021/security-patch-20210518-version-1-5-released for details.
 
✅  I've done a testrun of current builds of `opengever.core` against the most recent version of the fix in https://ci.4teamwork.ch/builds/439566.

Jira: https://4teamwork.atlassian.net/browse/CA-2600