### PR TITLE
Pin pyScss in general for all tests.

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -34,3 +34,7 @@ configparser = 3.8.1
 # six 1.12.0 provides ensure_text, ensure_binary and ensure_str helpers
 # which we use when porting to Python 3
 six = >=1.12.0
+
+# Version 1.4.0 depends on pathlib2 instead of pathlib
+# See https://github.com/Kronuz/pyScss/commit/38bbd607ff022bf5e65cf3a75c1b974576fca7b0
+pyScss <= 1.3.7


### PR DESCRIPTION
Version 1.4.0 depends on pathlib2 instead of pathlib