### PR TITLE
Pin some Py2.7 compatible versions for Plone 4 tests:

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -19,3 +19,8 @@ more-itertools = <6.0.0
 zipp = >=0.5, <2a
 inflection = <0.4.0
 importlib-metadata = <3a
+attrs = <22.1.0
+pycodestyle = <2.9.0
+testfixtures = <7.0.0
+pyflakes = <2.5.0
+collective.transmogrifier = <3.0.0


### PR DESCRIPTION
These package version constraints pin those packages to the latest Py2.7 compatible versions for the Plone 4 based test buildouts, which should fix most of the current nightly test failures.