### PR TITLE
Pin zc.buildout to >2,<3 for Python 2 based test versions:

### DIFF
--- a/bin/cibuild
+++ b/bin/cibuild
@@ -3,6 +3,6 @@
 set -e pipefail
 cd "$(dirname "$0")/../production-versions-buildout"
 
-$PYTHON27 bootstrap.py --setuptools-version 44.1.1
+$PYTHON27 bootstrap.py --setuptools-version 44.1.1 --buildout-version 2.13.8
 ./bin/buildout buildout:allow-picked-versions=false
 echo $?

--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -15,6 +15,7 @@ path.py = <11.2a
 
 # Python 2 compatibility versions (where newer versions drop Python 2 support).
 setuptools = <45.0
+zc.buildout = >2,<3
 more-itertools = <6.0.0
 zipp = >=0.5, <2a
 inflection = <0.4.0

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -17,6 +17,7 @@ path.py = <11.2a
 
 # Python 2 compatibility versions (where newer versions drop Python 2 support).
 setuptools = <45.0
+zc.buildout = >2,<3
 more-itertools = <6.0.0
 zipp = >=0.5, <2a
 inflection = <0.4.0


### PR DESCRIPTION
`zc.buildout == 3.0.0`, which was released today, dropped support for Python 2, and therefore needs to be constrained to a lower version for Python 2 based buildouts.

Therefore I added the version constraint `>2,<3` to the Python 3 based buildouts (`[test-versions-plone-4.cfg` and `test-versions-plone-5.cfg`), but not `test-versions-plone-5-py37.cfg`.

In order to bootstrap a buildout with Python 2, the buildout version now also needs to be specified:
`python27 bootstrap.py --setuptools-version 44.1.1 --buildout-version=2.13.8`