### PR TITLE
jenkins-run.py: Specify buildout version when bootstrapping buildouts with Py27

### DIFF
--- a/jenkins-run.py
+++ b/jenkins-run.py
@@ -75,6 +75,11 @@ class Main(object):
             # we use a regular python to bootstrap
             cmd = '%s bootstrap.py --setuptools-version 44.1.1' % python_path
 
+            # If bootstrap is run with Python2.7, we need to restrict the
+            # buildout version to <3
+            if 'python2.7' in python_path:
+                cmd += ' --buildout-version 2.13.8'
+
         runcmd_with_retries(
             cmd,
             rerun_needed,


### PR DESCRIPTION
`zc.buildout == 3.0.0` dropped Python 2.7 compatibility. Therefore when bootstrapping a buildout with Python 2.7, the buildout version also needs to be specified to the latest compatible version.

Also see 4teamwork/ftw-buildouts#201

The `'python2.7' in python_path` check is a bit fragile, but IMHO good enough for an urgent fix.