### PR TITLE
Pin z3c.dependencychecker to last compatible version for Py27 test versions

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -25,3 +25,4 @@ pycodestyle = <2.9.0
 testfixtures = <7.0.0
 pyflakes = <2.5.0
 collective.transmogrifier = <3.0.0
+z3c.dependencychecker = <2.8

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -22,3 +22,4 @@ more-itertools = <6.0.0
 zipp = >=0.5, <2a
 inflection = <0.4.0
 importlib-metadata = <3a
+z3c.dependencychecker = <2.8


### PR DESCRIPTION
Pin down `z3c.dependencychecker` to last compatible version for Py27 test versions.

Fixes CI failures like [these](https://ci.4teamwork.ch/builds/539917/tasks/1049744).