### PR TITLE
Pin cssselect to last compatible version for Py27 test versions

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -26,3 +26,4 @@ testfixtures = <7.0.0
 pyflakes = <2.5.0
 collective.transmogrifier = <3.0.0
 z3c.dependencychecker = <2.8
+cssselect = <1.2.0

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -23,3 +23,4 @@ zipp = >=0.5, <2a
 inflection = <0.4.0
 importlib-metadata = <3a
 z3c.dependencychecker = <2.8
+cssselect = <1.2.0


### PR DESCRIPTION
Pin `cssselect` to last compatible version for Py27 test versions.

Fixes test failure like [these](https://ci.4teamwork.ch/builds/540528/tasks/1052112).