### PR TITLE
jenkins-run.py: Fix bootstrapping of buildouts with Python 3:

### DIFF
--- a/jenkins-run.py
+++ b/jenkins-run.py
@@ -75,10 +75,15 @@ class Main(object):
             # we use a regular python to bootstrap
             cmd = '%s bootstrap.py --setuptools-version 44.1.1' % python_path
 
-            # If bootstrap is run with Python2.7, we need to restrict the
-            # buildout version to <3
-            if 'python2.7' in python_path:
-                cmd += ' --buildout-version 2.13.8'
+            # Use a known good version of buildout to bootstrap:
+            #
+            # - With Python 2.7, buildout >= 3.x doesn't work anymore because
+            #   it dropped Python 2.7 compatibility.
+            # - With Python 3.x, buildout >= 3.x stopped working at some point
+            #   because of an error during bootstrap:
+            #   pkg_resources.DistributionNotFound: The 'wheel' distribution
+            #   was not found and is required by zc.buildout
+            cmd += ' --buildout-version 2.13.8'
 
         runcmd_with_retries(
             cmd,


### PR DESCRIPTION
`zc.buildout >= 3` never was compatible with Python 2.7, and we therefore had to explicitly use the last 2.x version when bootstrapping (see #202).

We only did this conditionally for Python 2.7 though. Now it seems that bootstrapping with `zc.buildout >= 3` has also stopped working for Python 3, because of an error like this during bootstrap:

```
pkg_resources.DistributionNotFound: The 'wheel' distribution was not found and
is required by zc.buildout
```

We therefore unconditionally use buildout `2.13.8` for bootstrapping on Jenkins.

For [CA-1243](https://4teamwork.atlassian.net/browse/CA-1243) and [CA-1240](https://4teamwork.atlassian.net/browse/CA-1240)

Should fix test failures like [these](https://ci.4teamwork.ch/builds/540822/tasks/1053209).

