### PR TITLE
Bump c.xmltestreport to 2.0.2 (fixes Plone 5 tests):

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -193,7 +193,7 @@ on_install=true
 on_update=true
 cfgfile = ${buildout:directory}/parts/pycodestyle/pycodestyle.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pycodestyle.cfg
-cmds = 
+cmds =
     mkdir -p `dirname ${pycodestyle-cfg:cfgfile}`
     curl "${pycodestyle-cfg:cfgurl}" > "${pycodestyle-cfg:cfgfile}"
 
@@ -237,7 +237,7 @@ on_install=true
 on_update=true
 cfgfile = ${buildout:directory}/parts/pydocstyle/pydocstyle.cfg
 cfgurl = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/pydocstyle.cfg
-cmds = 
+cmds =
     mkdir -p `dirname ${pydocstyle-cfg:cfgfile}`
     curl "${pydocstyle-cfg:cfgurl}" > "${pydocstyle-cfg:cfgfile}"
 
@@ -469,4 +469,4 @@ scripts = dependencychecker
 
 [versions]
 collective.recipe.cmd = 0.11
-collective.xmltestreport = 2.0.1
+collective.xmltestreport = 2.0.2


### PR DESCRIPTION
Bump `collective.xmltestreport` to [2.0.2](https://github.com/collective/collective.xmltestreport/blob/master/CHANGES.rst#202-2020-03-09)

This fixes

```
TypeError: test_failure() got an unexpected keyword argument 'stdout'
```

when running collective.xmltestreport with a version of `zope.testrunner >= 5.1` (which is the case for some Plone 5 buildouts).

For [CA-1243](https://4teamwork.atlassian.net/browse/CA-1243) and [CA-1240](https://4teamwork.atlassian.net/browse/CA-1240)

Should fix test failures like [these](https://ci.4teamwork.ch/builds/540838/tasks/1053246).