### PR TITLE
Fix bin/pyflakes and bin/zptlint for Python 3:

### DIFF
--- a/test-base.cfg
+++ b/test-base.cfg
@@ -320,7 +320,7 @@ initialization =
             '${buildout:directory}/bin/package-directory relative',
             shell=True,
             stdout=subprocess.PIPE,
-            ).stdout.read().strip()
+            ).stdout.read().decode('utf-8').strip()
 
         # We filter by filetype, filename and add our ignores
         files = subprocess.Popen(
@@ -335,7 +335,7 @@ initialization =
                 "! -path '*/skins/*' "
             ).format(pkgdir),
             shell=True,
-            stdout=subprocess.PIPE).stdout.read().splitlines()
+            stdout=subprocess.PIPE).stdout.read().decode('utf-8').splitlines()
 
         sys.argv.extend(files)
 
@@ -350,10 +350,10 @@ initialization =
     import subprocess
     pkgdir = subprocess.Popen(
         '${buildout:directory}/bin/package-directory relative',
-        shell=True, stdout=subprocess.PIPE).stdout.read().strip()
+        shell=True, stdout=subprocess.PIPE).stdout.read().decode('utf-8').strip()
     ptfiles = subprocess.Popen(
         'find %s -name "*.pt"' % pkgdir,
-        shell=True, stdout=subprocess.PIPE).stdout.read().strip()
+        shell=True, stdout=subprocess.PIPE).stdout.read().decode('utf-8').strip()
     sys.argv.extend(ptfiles and ptfiles.split('\n') or [])
     if len(sys.argv) == 1: sys.exit(0)
 


### PR DESCRIPTION
Fix `bin/pyflakes` and `bin/zptlint` for Python 3:

`stdout.read()` from a `subprocess.PIPE` returns a bytestring.

In Python, string interpolation (using `%s` or `.format()`) will implicitly do the equivalent of `str(bytestring)` (Py3) / `unicode(bytestring)` (Py2) when a bytestring is used for interpolation in a unicode template string.

- On Python 2, this will implicitly try to decode the bytestring using the 'ascii' codec (possibly resulting in an `UnicodeDecodeError`, but otherwise working fine if no non-ASCII characters are present).

- On Python 3 however, [`bytes.__str__()` delegates to `__repr__()`](https://github.com/python/cpython/blob/692e9078a10b268530f8da7d3095cfb05c48435b/Objects/bytesobject.c#L1363-L1373), and therefore will always "succeed", but injecting strings including the literal `b'...'` notation of their `__repr__`.

This leads to strange errors like
```
find: bftw/testbrowser: No such file or directory
      ^
```

_(The single quotes from this error when running the `bin/pyflakes` script got lost here because the malformed string was used as an argument in a shell context)_

For [CA-1243](https://4teamwork.atlassian.net/browse/CA-1243) and [CA-1240](https://4teamwork.atlassian.net/browse/CA-1240)