### PR TITLE
Pin icalendar to <5 for Python 2.7 test versions

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -27,3 +27,4 @@ pyflakes = <2.5.0
 collective.transmogrifier = <3.0.0
 z3c.dependencychecker = <2.8
 cssselect = <1.2.0
+icalendar = <5.0.0

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -24,3 +24,4 @@ inflection = <0.4.0
 importlib-metadata = <3a
 z3c.dependencychecker = <2.8
 cssselect = <1.2.0
+icalendar = <5.0.0


### PR DESCRIPTION
According to icalendar's README, the 5.x branch doesn't support Python 2.7 any more (even though it mostly still seems to work).

However, release 5.0.3 of icalendar started using `setuptools.find_namespace_packages()`, which breaks on some setuptools versions.

This is not a problem in most recent Plone versions that specifically pin known good versions of icalendar (and always pin it to versions < 5), but some older Plone versions like 4.3.7 don't have a version pinning of icalendar yet, so this should fix testing for those.

For [CA-1243](https://4teamwork.atlassian.net/browse/CA-1243)

Should fix test failures like [these](https://ci.4teamwork.ch/builds/540902/tasks/1053398).