### PR TITLE
Pin testfixtures to <7.0.0 for Python 2 test versions:

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -28,3 +28,4 @@ collective.transmogrifier = <3.0.0
 z3c.dependencychecker = <2.8
 cssselect = <1.2.0
 icalendar = <5.0.0
+testfixtures = <7.0.0

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -25,3 +25,4 @@ importlib-metadata = <3a
 z3c.dependencychecker = <2.8
 cssselect = <1.2.0
 icalendar = <5.0.0
+testfixtures = <7.0.0


### PR DESCRIPTION
`testfixtures >= 7.0.0` dropped Python 2.7 support.

For [CA-1243](https://4teamwork.atlassian.net/browse/CA-1243)

Fixes test failures like [these](https://ci.4teamwork.ch/builds/540856/tasks/1053268).

