### PR TITLE
Fix tests by pinning down pydocstyle:

### DIFF
--- a/test-versions.cfg
+++ b/test-versions.cfg
@@ -38,3 +38,7 @@ six = >=1.12.0
 # Version 1.4.0 depends on pathlib2 instead of pathlib
 # See https://github.com/Kronuz/pyScss/commit/38bbd607ff022bf5e65cf3a75c1b974576fca7b0
 pyScss = <=1.3.7
+
+# Pin down pydocstyle because recent versions require snowballstemmer >=2.2.0,
+# which is pinned to an 1.x version even by Plone 5.x.
+pydocstyle = <6.2.0


### PR DESCRIPTION
Pin down `pydocstyle` because recent versions require `snowballstemmer >= 2.2.0`, which is pinned to an 1.x version even by Plone 5.x.

This should fix test failures like [these](https://ci.4teamwork.ch/builds/543234/tasks/1061487).