### PR TITLE
Add test buildout for Plone 5.2 with Python 3.8

### DIFF
--- a/test-plone-5.2.x-py38.cfg
+++ b/test-plone-5.2.x-py38.cfg
@@ -1,0 +1,19 @@
+[buildout]
+extends =
+    https://dist.plone.org/release/5.2-latest/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-5-py38.cfg
+
+jenkins_python = $PYTHON38
+
+
+
+[test]
+eggs +=
+    Pillow
+
+
+[versions]
+# Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
+zc.recipe.egg = 2.0.3

--- a/test-versions-plone-5-py38.cfg
+++ b/test-versions-plone-5-py38.cfg
@@ -1,0 +1,16 @@
+# Plone 5.x version pinnings.
+# This file contains suggested version pinnings as constraints.
+# These version pinnings take effect when a project does not pin
+# versions at all.
+
+[versions]
+collective.z3cform.datagridfield = >=1.4
+
+# Constrain to PAM compatible with Plone 5.1. Once Plone 5.2 final is released,
+# we should probably split up this file into 5.1/5.2.
+plone.app.multilingual = >5a,<5.4
+
+# path.py==12.0.1 has dropped Python 2.7 support.
+# path.py==11.2.0 has started using importlib_metadata, which does not work well
+# with buildout.
+path.py = <11.2a


### PR DESCRIPTION
Add test buildout for Plone 5.2 with Python 3.8.

A Python 3.8 installation and the `PYTHON38` env var is already present on Jenkins.  

For [CA-2571](https://4teamwork.atlassian.net/browse/CA-2571)