### PR TITLE
Pin down setuptools to <67

### DIFF
--- a/test-versions-plone-5-py37.cfg
+++ b/test-versions-plone-5-py37.cfg
@@ -14,3 +14,7 @@ plone.app.multilingual = >5a,<5.4
 # path.py==11.2.0 has started using importlib_metadata, which does not work well
 # with buildout.
 path.py = <11.2a
+
+# setuptools 67 doesn't like the requirements in CMFPlone 5.2
+# (e.g. plone.app.contentmenu >=1.1.6dev-r22380)
+setuptools = <67

--- a/test-versions-plone-5-py38.cfg
+++ b/test-versions-plone-5-py38.cfg
@@ -14,3 +14,7 @@ plone.app.multilingual = >5a,<5.4
 # path.py==11.2.0 has started using importlib_metadata, which does not work well
 # with buildout.
 path.py = <11.2a
+
+# setuptools 67 doesn't like the requirements in CMFPlone 5.2
+# (e.g. plone.app.contentmenu >=1.1.6dev-r22380)
+setuptools = <67


### PR DESCRIPTION
setuptools 67 doesn't accept some requirements currently present in CMFPlone 5.2 (e.g. `plone.app.contentmenu >=1.1.6dev-r22380`).