### PR TITLE
Add reserved port for gever-ui to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,7 @@ For example if we use ``deployment-number = 05`` the ports would be:
   10530, "bin/solr-instance", "Solr instance"
   10532, "bin/tika-server", "Tika JAXRS Server"
   10533, "bin/redis", "Redis instance"
+  10534, "gever-ui", "Frontend for Gever deployments"
   10550, "bin/haproxy", "Haproxy (reserved, not installation yet)"
   10581, "Monitor for instance1", "ftw.monitor TCP socket for health checks"
   "...", "Monitor for instance...", "..."


### PR DESCRIPTION
We now include the gever-ui compose file into the corresponding policies and run docker from the same folder. This means we need to reserve a port for the frontend in the range used for the deployment.

For https://4teamwork.atlassian.net/browse/CA-5753