### PR TITLE
Constrain argcomplete version for python 2 compatibility.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -25,3 +25,6 @@ collective.z3cform.colorpicker = 1.4
 
 # geopy >= 2.0 is no longer python 2 compatible
 geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -20,3 +20,6 @@ zc.recipe.egg = 2.0.3
 
 # geopy >= 2.0 is no longer python 2 compatible
 geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -20,3 +20,6 @@ zc.recipe.egg = 2.0.3
 
 # geopy >= 2.0 is no longer python 2 compatible
 geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2


### PR DESCRIPTION
Should fix the many failing nightly builds