### PR TITLE
Pin geopy and argcomplete to latest python 2 compatible version.

### DIFF
--- a/test-plone-5.0.2.cfg
+++ b/test-plone-5.0.2.cfg
@@ -12,3 +12,11 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.0.3.cfg
+++ b/test-plone-5.0.3.cfg
@@ -12,3 +12,11 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.0.4.cfg
+++ b/test-plone-5.0.4.cfg
@@ -12,3 +12,11 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.0.5.cfg
+++ b/test-plone-5.0.5.cfg
@@ -12,3 +12,11 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.0.6.cfg
+++ b/test-plone-5.0.6.cfg
@@ -8,6 +8,15 @@ extends =
 jenkins_python = $PYTHON27
 
 
+
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.0.8.cfg
+++ b/test-plone-5.0.8.cfg
@@ -12,3 +12,11 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.0.cfg
+++ b/test-plone-5.0.cfg
@@ -12,3 +12,11 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.0.x.cfg
+++ b/test-plone-5.0.x.cfg
@@ -8,10 +8,15 @@ extends =
 jenkins_python = $PYTHON27
 
 
+
 [test]
 eggs +=
     Pillow
 
+
 [versions]
 # geopy >= 2.0 is no longer python 2 compatible
 geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.1.0.cfg
+++ b/test-plone-5.1.0.cfg
@@ -17,3 +17,9 @@ eggs +=
 [versions]
 # Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
 zc.recipe.egg = 2.0.3
+
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.1.1.cfg
+++ b/test-plone-5.1.1.cfg
@@ -17,3 +17,9 @@ eggs +=
 [versions]
 # Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
 zc.recipe.egg = 2.0.3
+
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.1.5.cfg
+++ b/test-plone-5.1.5.cfg
@@ -17,3 +17,9 @@ eggs +=
 [versions]
 # Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
 zc.recipe.egg = 2.0.3
+
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.1.6.cfg
+++ b/test-plone-5.1.6.cfg
@@ -17,3 +17,9 @@ eggs +=
 [versions]
 # Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
 zc.recipe.egg = 2.0.3
+
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.1.7.cfg
+++ b/test-plone-5.1.7.cfg
@@ -17,3 +17,9 @@ eggs +=
 [versions]
 # Downgrade zc.recipe.egg because 2.0.4 seems to be a broken build.
 zc.recipe.egg = 2.0.3
+
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2

--- a/test-plone-5.x.cfg
+++ b/test-plone-5.x.cfg
@@ -12,3 +12,11 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+
+[versions]
+# geopy >= 2.0 is no longer python 2 compatible
+geopy = <2.0.dev0
+
+# argcomplete >= 2.0 is no longer python 2 compatible
+argcomplete = <2


### PR DESCRIPTION
Follow-up for https://github.com/4teamwork/ftw-buildouts/pull/215 where I forgot to also pin argcomplete in `test-plone-5.0.x.cfg`. I also add the pin to all other plone 5 python 2 buildouts which were most likely broken too (although I don't think we ever use those buildout files anywhere).