### PR TITLE
Pin stdlib-list to last python 2 compatible version where necessary.

### DIFF
--- a/test-plone-4.3.0.cfg
+++ b/test-plone-4.3.0.cfg
@@ -20,3 +20,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.1.cfg
+++ b/test-plone-4.3.1.cfg
@@ -20,3 +20,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.10.cfg
+++ b/test-plone-4.3.10.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.11.cfg
+++ b/test-plone-4.3.11.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.14.cfg
+++ b/test-plone-4.3.14.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.15.cfg
+++ b/test-plone-4.3.15.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.17.cfg
+++ b/test-plone-4.3.17.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.18.cfg
+++ b/test-plone-4.3.18.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.19.cfg
+++ b/test-plone-4.3.19.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.2.cfg
+++ b/test-plone-4.3.2.cfg
@@ -19,3 +19,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.20.cfg
+++ b/test-plone-4.3.20.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.3.cfg
+++ b/test-plone-4.3.3.cfg
@@ -18,3 +18,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.4.cfg
+++ b/test-plone-4.3.4.cfg
@@ -18,3 +18,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.5.cfg
+++ b/test-plone-4.3.5.cfg
@@ -24,3 +24,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.6.cfg
+++ b/test-plone-4.3.6.cfg
@@ -24,3 +24,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -18,3 +18,6 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.8.cfg
+++ b/test-plone-4.3.8.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.9.cfg
+++ b/test-plone-4.3.9.cfg
@@ -12,3 +12,7 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
+
+[versions]
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -28,3 +28,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.2.cfg
+++ b/test-plone-5.0.2.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.3.cfg
+++ b/test-plone-5.0.3.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.4.cfg
+++ b/test-plone-5.0.4.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.5.cfg
+++ b/test-plone-5.0.5.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.6.cfg
+++ b/test-plone-5.0.6.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.8.cfg
+++ b/test-plone-5.0.8.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.cfg
+++ b/test-plone-5.0.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.0.x.cfg
+++ b/test-plone-5.0.x.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -23,3 +23,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9

--- a/test-plone-5.x.cfg
+++ b/test-plone-5.x.cfg
@@ -20,3 +20,6 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
+
+# stdlib-list >= 0.9 is no longer python 2 compatible
+stdlib-list = <0.9


### PR DESCRIPTION
Should fix all the failing policies.