### PR TITLE
Pin stdlib-list to last python2 compativle version in more cfg files.

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -29,3 +29,4 @@ z3c.dependencychecker = <2.8
 cssselect = <1.2.0
 icalendar = <5.0.0
 testfixtures = <7.0.0
+stdlib-list = <0.9

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -26,3 +26,4 @@ z3c.dependencychecker = <2.8
 cssselect = <1.2.0
 icalendar = <5.0.0
 testfixtures = <7.0.0
+stdlib-list = <0.9


### PR DESCRIPTION
Two more files where we need to pin stdlib-list. This is necessary for local buildout of Gever.