### PR TITLE
Pin plone.rest to last python 2 compatible version.

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -30,3 +30,4 @@ cssselect = <1.2.0
 icalendar = <5.0.0
 testfixtures = <7.0.0
 stdlib-list = <0.9
+plone.rest = <4.0.0

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -27,3 +27,4 @@ cssselect = <1.2.0
 icalendar = <5.0.0
 testfixtures = <7.0.0
 stdlib-list = <0.9
+plone.rest = <4.0.0


### PR DESCRIPTION
Should fix failing nightly builds such as https://ci.4teamwork.ch/builds/574956/tasks/1154720