### PR TITLE
Remove unnecessary stdlib-list pinnings.

### DIFF
--- a/test-plone-4.3.0.cfg
+++ b/test-plone-4.3.0.cfg
@@ -20,6 +20,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.1.cfg
+++ b/test-plone-4.3.1.cfg
@@ -20,6 +20,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.10.cfg
+++ b/test-plone-4.3.10.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.11.cfg
+++ b/test-plone-4.3.11.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.14.cfg
+++ b/test-plone-4.3.14.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.15.cfg
+++ b/test-plone-4.3.15.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.17.cfg
+++ b/test-plone-4.3.17.cfg
@@ -8,11 +8,6 @@ extends =
 jenkins_python = $PYTHON27
 
 
-
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.18.cfg
+++ b/test-plone-4.3.18.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.19.cfg
+++ b/test-plone-4.3.19.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.2.cfg
+++ b/test-plone-4.3.2.cfg
@@ -19,6 +19,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.20.cfg
+++ b/test-plone-4.3.20.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.3.cfg
+++ b/test-plone-4.3.3.cfg
@@ -18,6 +18,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.4.cfg
+++ b/test-plone-4.3.4.cfg
@@ -18,6 +18,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.5.cfg
+++ b/test-plone-4.3.5.cfg
@@ -24,6 +24,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.6.cfg
+++ b/test-plone-4.3.6.cfg
@@ -24,6 +24,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.7.cfg
+++ b/test-plone-4.3.7.cfg
@@ -18,6 +18,3 @@ eggs +=
 # plone.formwidget.datetime 1.3 is incompatible with Plone <= 4.3.7
 # https://github.com/plone/Products.CMFPlone/issues/983#issuecomment-183371429
 plone.formwidget.datetime = 1.2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.8.cfg
+++ b/test-plone-4.3.8.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.9.cfg
+++ b/test-plone-4.3.9.cfg
@@ -12,7 +12,3 @@ jenkins_python = $PYTHON27
 [test]
 eggs +=
     Pillow
-
-[versions]
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -28,6 +28,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.2.cfg
+++ b/test-plone-5.0.2.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.3.cfg
+++ b/test-plone-5.0.3.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.4.cfg
+++ b/test-plone-5.0.4.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.5.cfg
+++ b/test-plone-5.0.5.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.6.cfg
+++ b/test-plone-5.0.6.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.8.cfg
+++ b/test-plone-5.0.8.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.cfg
+++ b/test-plone-5.0.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.0.x.cfg
+++ b/test-plone-5.0.x.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.1.0.cfg
+++ b/test-plone-5.1.0.cfg
@@ -23,6 +23,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.1.1.cfg
+++ b/test-plone-5.1.1.cfg
@@ -23,6 +23,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.1.5.cfg
+++ b/test-plone-5.1.5.cfg
@@ -23,6 +23,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.1.6.cfg
+++ b/test-plone-5.1.6.cfg
@@ -23,6 +23,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.1.7.cfg
+++ b/test-plone-5.1.7.cfg
@@ -23,6 +23,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -23,6 +23,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -23,6 +23,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9

--- a/test-plone-5.x.cfg
+++ b/test-plone-5.x.cfg
@@ -20,6 +20,3 @@ geopy = <2.0.dev0
 
 # argcomplete >= 2.0 is no longer python 2 compatible
 argcomplete = <2
-
-# stdlib-list >= 0.9 is no longer python 2 compatible
-stdlib-list = <0.9


### PR DESCRIPTION
As stdlib-list is pinned in test-versions-plone-4.cfg and in test-versions-plone-5.cfg, we do not need to pin it in all the other buildout files which extend one of the above. When I pinned `stdlib-list`, I started i the various buildout files for specific plone versions, I hadn't realised I should simply pin it centrally. I've done that since but have not cleaned up.

