### PR TITLE
Remove plone.rest pinning

### DIFF
--- a/test-versions-plone-4.cfg
+++ b/test-versions-plone-4.cfg
@@ -30,4 +30,3 @@ cssselect = <1.2.0
 icalendar = <5.0.0
 testfixtures = <7.0.0
 stdlib-list = <0.9
-plone.rest = <4.0.0

--- a/test-versions-plone-5.cfg
+++ b/test-versions-plone-5.cfg
@@ -27,4 +27,3 @@ cssselect = <1.2.0
 icalendar = <5.0.0
 testfixtures = <7.0.0
 stdlib-list = <0.9
-plone.rest = <4.0.0


### PR DESCRIPTION
We should not override pinnings of non-test requirements here.