### PR TITLE
Add find-links for individual packages hosted on GitLab

### DIFF
--- a/4teamwork-psc.cfg
+++ b/4teamwork-psc.cfg
@@ -1,3 +1,11 @@
 [buildout]
 extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/authentication.cfg
-find-links += https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple
+find-links +=
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/docxcompose
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-bumblebee
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-flamegraph
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-zopemaster
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/opengever-core
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapmultiplugins
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapuserfolder
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/relstorage

--- a/4teamwork-psc.cfg
+++ b/4teamwork-psc.cfg
@@ -1,5 +1,4 @@
 [buildout]
-extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/authentication.cfg
 find-links +=
     https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/docxcompose
     https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-bumblebee


### PR DESCRIPTION
Add `find-links` for individual packages hosted on GitLab:

With the GitLab registry for Python packages, using the simple index doesn't work with buildout, because it contains subpages that aren't processed by setuptools. Instead, the URLs to the individual packages need to be listed explicitly in find-links.

In addition, I made `4teamwork-psc.cfg` not extend from `authentication.cfg` (which just adds the `isotoma.buildout.basicauth` extension) . Recent versions of setuptools read credentials from `.pypirc` automatically, and then extension therefore isn't needed anymore. However, because [more than 100](https://github.com/search?q=org%3A4teamwork%20authentication.cfg&type=code) buildouts still extend from `authentication.cfg` directly, I'm not removing the file itself yet. 

